### PR TITLE
Add region to physicalLocation

### DIFF
--- a/cli/src/main/java/io/codiga/cli/model/sarif/SarifRegion.java
+++ b/cli/src/main/java/io/codiga/cli/model/sarif/SarifRegion.java
@@ -1,0 +1,22 @@
+package io.codiga.cli.model.sarif;
+
+import io.codiga.cli.model.ViolationWithFilename;
+import lombok.Builder;
+
+@Builder
+public class SarifRegion {
+    public Integer startLine;
+    public Integer startColumn;
+    public Integer endLine;
+    public Integer endColumn;
+
+    public static SarifRegion generate(ViolationWithFilename violation) {
+        return SarifRegion
+            .builder()
+            .startLine(violation.start == null ? null : violation.start.line)
+            .startColumn(violation.start == null ? null : violation.start.col)
+            .endLine(violation.end == null ? null : violation.end.line)
+            .endColumn(violation.end == null ? null : violation.end.col)
+            .build();
+    }
+}

--- a/cli/src/main/java/io/codiga/cli/model/sarif/SarifResult.java
+++ b/cli/src/main/java/io/codiga/cli/model/sarif/SarifResult.java
@@ -18,11 +18,11 @@ public class SarifResult {
 
     public static SarifResult generate(ViolationWithFilename violation) {
         return SarifResult
-                .builder()
-                .level(severityToSarifLevel(violation.severity))
-                .message(SarifResultMessage.builder().text(violation.message).build())
-                .locations(List.of(SarifResultLocation.generate(violation.filename)))
-                .ruleId(violation.rule)
-                .build();
+            .builder()
+            .level(severityToSarifLevel(violation.severity))
+            .message(SarifResultMessage.builder().text(violation.message).build())
+            .locations(List.of(SarifResultLocation.generate(violation)))
+            .ruleId(violation.rule)
+            .build();
     }
 }

--- a/cli/src/main/java/io/codiga/cli/model/sarif/SarifResultArtifactLocation.java
+++ b/cli/src/main/java/io/codiga/cli/model/sarif/SarifResultArtifactLocation.java
@@ -11,15 +11,20 @@ public class SarifResultArtifactLocation {
 
     public static SarifResultArtifactLocation generate(Path path) {
         return SarifResultArtifactLocation
-                .builder()
-                .uri(path.toUri().toString())
-                .build();
+            .builder()
+            .uri(path.toUri().toString())
+            .build();
     }
 
     public static SarifResultArtifactLocation generate(String uri) {
+        String finalUri = uri;
+        if (uri.startsWith("/")) {
+            finalUri = uri.substring(1);
+        }
+
         return SarifResultArtifactLocation
-                .builder()
-                .uri(uri)
-                .build();
+            .builder()
+            .uri(finalUri)
+            .build();
     }
 }

--- a/cli/src/main/java/io/codiga/cli/model/sarif/SarifResultLocation.java
+++ b/cli/src/main/java/io/codiga/cli/model/sarif/SarifResultLocation.java
@@ -1,15 +1,18 @@
 package io.codiga.cli.model.sarif;
 
+import io.codiga.cli.model.ViolationWithFilename;
 import lombok.Builder;
 
 @Builder
 public class SarifResultLocation {
     public SarifResultPhysicalLocation physicalLocation;
 
-    public static SarifResultLocation generate(String uri) {
+
+    public static SarifResultLocation generate(ViolationWithFilename violation) {
         return SarifResultLocation
-                .builder()
-                .physicalLocation(SarifResultPhysicalLocation.generate(uri))
-                .build();
+            .builder()
+            .physicalLocation(SarifResultPhysicalLocation.generate(violation))
+            .build();
     }
+
 }

--- a/cli/src/main/java/io/codiga/cli/model/sarif/SarifResultPhysicalLocation.java
+++ b/cli/src/main/java/io/codiga/cli/model/sarif/SarifResultPhysicalLocation.java
@@ -1,15 +1,18 @@
 package io.codiga.cli.model.sarif;
 
+import io.codiga.cli.model.ViolationWithFilename;
 import lombok.Builder;
 
 @Builder
 public class SarifResultPhysicalLocation {
     public SarifResultArtifactLocation artifactLocation;
+    public SarifRegion region;
 
-    public static SarifResultPhysicalLocation generate(String uri) {
+    public static SarifResultPhysicalLocation generate(ViolationWithFilename violation) {
         return SarifResultPhysicalLocation
-                .builder()
-                .artifactLocation(SarifResultArtifactLocation.generate(uri))
-                .build();
+            .builder()
+            .artifactLocation(SarifResultArtifactLocation.generate(violation.filename))
+            .region(SarifRegion.generate(violation))
+            .build();
     }
 }

--- a/cli/src/test/java/io/codiga/cli/utils/SarifUtilsTest.java
+++ b/cli/src/test/java/io/codiga/cli/utils/SarifUtilsTest.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import java.util.logging.Logger;
 
 import static io.codiga.cli.utils.SarifUtils.generateReport;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class SarifUtilsTest {
@@ -76,7 +77,18 @@ public class SarifUtilsTest {
             generateReport(
                 List.of(new AnalyzerRule("myrule", Language.PYTHON, RuleType.AST_CHECK, EntityChecked.ASSIGNMENT, "code", null, null, Map.of())),
                 List.of(new File("foo/bar").toPath()),
-                List.of(new ViolationWithFilename(new Position(0, 1), new Position(1, 2), "error message", Severity.CRITICAL, Category.BEST_PRACTICE, "myfile", "myrule")),
+                List.of(new ViolationWithFilename(new Position(1, 2), new Position(2, 3), "error message", Severity.CRITICAL, Category.BEST_PRACTICE, "myfile", "myrule")),
+                List.of())));
+    }
+
+    @Test
+    @DisplayName("Violations that starts at line 0 are invalid")
+    public void testInvalidLineNumbers() {
+        assertFalse(checkCompliance(
+            generateReport(
+                List.of(new AnalyzerRule("myrule", Language.PYTHON, RuleType.AST_CHECK, EntityChecked.ASSIGNMENT, "code", null, null, Map.of())),
+                List.of(new File("foo/bar").toPath()),
+                List.of(new ViolationWithFilename(new Position(0, 2), new Position(2, 3), "error message", Severity.CRITICAL, Category.BEST_PRACTICE, "myfile", "myrule")),
                 List.of())));
     }
 }


### PR DESCRIPTION
**What problem are we trying to solve?**

We want to export the location of a violation in the SARIF file.
We also want to remove the leading slash in the filenames being exported.


**Solution**

1. Export the `region` data in the `physicalLocation`
2. Remove the trailing space for the filename inside the repository