### PR TITLE
update getFullAstTree to use isNamed function

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -33,6 +33,7 @@ java.targetCompatibility = JavaVersion.VERSION_17
 
 dependencies {
     implementation("com.fasterxml.jackson.core:jackson-annotations:2.14.2")
+    implementation("com.fasterxml.jackson.core:jackson-databind:2.14.2")
     implementation("com.google.inject:guice:5.1.0")
     implementation("com.datadoghq:java-dogstatsd-client:4.2.0")
     implementation("com.datadoghq:dd-trace-api:1.10.0")

--- a/core/src/main/java/io/codiga/model/ast/common/TreeSitterAstElement.java
+++ b/core/src/main/java/io/codiga/model/ast/common/TreeSitterAstElement.java
@@ -1,13 +1,18 @@
 package io.codiga.model.ast.common;
 
-import ai.serenade.treesitter.Position;
+import ai.serenade.treesitter.Node;
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import io.codiga.model.common.Position;
+import lombok.Builder;
+import lombok.extern.jackson.Jacksonized;
 
 import java.util.List;
 
 /**
  * Represents a TreeSitter AST element
  */
+@Builder
+@Jacksonized // allows Jackson to deserialize on the builder class
 public class TreeSitterAstElement {
     public String astType;
     public io.codiga.model.common.Position start;
@@ -16,16 +21,15 @@ public class TreeSitterAstElement {
     public List<TreeSitterAstElement> children;
     @JsonIgnore public TreeSitterAstElement parent; // only used while traversing a tree; don't return in API requests
 
-    public TreeSitterAstElement() {
-        // leave empty for tests
-    }
-
-    public TreeSitterAstElement(String astType, Position start, Position end, String fieldName, List<TreeSitterAstElement> children, TreeSitterAstElement parent) {
-        this.astType = astType;
-        this.start = new io.codiga.model.common.Position(start.row, start.column);
-        this.end = new io.codiga.model.common.Position(end.row, end.column);
-        this.fieldName = fieldName;
-        this.children = children;
-        this.parent = parent;
+    public static TreeSitterAstElement create(Node node, String fieldName, List<TreeSitterAstElement> children, TreeSitterAstElement parent) {
+        return TreeSitterAstElement
+                .builder()
+                .astType(node.getType())
+                .start(new Position(node.getStartPosition().row, node.getStartPosition().column))
+                .end(new Position(node.getEndPosition().row, node.getEndPosition().column))
+                .fieldName(fieldName)
+                .children(children)
+                .parent(parent)
+                .build();
     }
 }

--- a/core/src/main/java/io/codiga/utils/TreeSitterUtils.java
+++ b/core/src/main/java/io/codiga/utils/TreeSitterUtils.java
@@ -79,7 +79,7 @@ public class TreeSitterUtils {
                 }
             } else {
                 if (treeCursor.getCurrentNode().isNamed()) {
-                    current = new TreeSitterAstElement(treeCursor.getCurrentNode().getType(), treeCursor.getCurrentNode().getStartPosition(), treeCursor.getCurrentNode().getEndPosition(), treeCursor.getCurrentFieldName(), new ArrayList<>(), parent);
+                    current = TreeSitterAstElement.create(treeCursor.getCurrentNode(), treeCursor.getCurrentFieldName(), new ArrayList<>(), parent);
                     if (parent != null) {
                         parent.children.add(current);
                     }


### PR DESCRIPTION
#### What problem are we trying to solve?

We want to use the newly supported (#15) isNamed() function over checking the node's type ourselves.

#### Solution

Replace code to use the `isNamed` method

#### Notes

- made the `TreeSitterAstElement` into a builder and added a `create` function on it
  - added `.fasterxml.jackson.core:jackson-databind` in the core to automatically configure the generated builder class to be used by Jackson's deserialization
