### PR TITLE
add description and link to JSON schema for SARIF files

### DIFF
--- a/cli/src/main/java/io/codiga/cli/model/sarif/SarifArtifact.java
+++ b/cli/src/main/java/io/codiga/cli/model/sarif/SarifArtifact.java
@@ -4,6 +4,11 @@ import lombok.Builder;
 
 import java.nio.file.Path;
 
+/**
+ * A single artifact. In some cases, this artifact might be nested within another artifact.
+ * <br>
+ * <a href="https://github.com/DataDog/datadog-ci/blob/master/src/commands/sarif/json-schema/sarif-schema-2.1.0.json#L117L2339">See in the SARIF JSON Schema</a>
+ */
 @Builder
 public class SarifArtifact {
     public SarifArtifactLocation location;

--- a/cli/src/main/java/io/codiga/cli/model/sarif/SarifArtifactChange.java
+++ b/cli/src/main/java/io/codiga/cli/model/sarif/SarifArtifactChange.java
@@ -6,6 +6,11 @@ import lombok.Builder;
 import java.util.List;
 import java.util.Optional;
 
+/**
+ * A change to a single artifact.
+ * <br>
+ * <a href="https://github.com/DataDog/datadog-ci/blob/master/src/commands/sarif/json-schema/sarif-schema-2.1.0.json#L230">See in the SARIF JSON Schema</a>
+ */
 @Builder
 public class SarifArtifactChange {
     public SarifArtifactLocation artifactLocation;

--- a/cli/src/main/java/io/codiga/cli/model/sarif/SarifArtifactContent.java
+++ b/cli/src/main/java/io/codiga/cli/model/sarif/SarifArtifactContent.java
@@ -2,6 +2,11 @@ package io.codiga.cli.model.sarif;
 
 import lombok.Builder;
 
+/**
+ * Represents the contents of an artifact.
+ * <br>
+ * <a href="https://github.com/DataDog/datadog-ci/blob/master/src/commands/sarif/json-schema/sarif-schema-2.1.0.json#L261">See in the SARIF JSON Schema</a>
+ */
 @Builder
 public class SarifArtifactContent {
     public String text;

--- a/cli/src/main/java/io/codiga/cli/model/sarif/SarifArtifactLocation.java
+++ b/cli/src/main/java/io/codiga/cli/model/sarif/SarifArtifactLocation.java
@@ -6,6 +6,11 @@ import java.nio.file.Path;
 
 import static io.codiga.cli.utils.SarifUtils.stripLeadingSlash;
 
+/**
+ * Specifies the location of an artifact.
+ * <br>
+ * <a href="https://github.com/DataDog/datadog-ci/blob/master/src/commands/sarif/json-schema/sarif-schema-2.1.0.json#L289">See in the SARIF JSON Schema</a>
+ */
 @Builder
 public class SarifArtifactLocation {
     public String uri;

--- a/cli/src/main/java/io/codiga/cli/model/sarif/SarifRegion.java
+++ b/cli/src/main/java/io/codiga/cli/model/sarif/SarifRegion.java
@@ -3,6 +3,11 @@ package io.codiga.cli.model.sarif;
 import io.codiga.cli.model.ViolationWithFilename;
 import lombok.Builder;
 
+/**
+ * A region within an artifact where a result was detected.
+ * <br>
+ * <a href="https://github.com/DataDog/datadog-ci/blob/master/src/commands/sarif/json-schema/sarif-schema-2.1.0.json#L1711">See in the SARIF JSON Schema</a>
+ */
 @Builder
 public class SarifRegion {
     public Integer startLine;

--- a/cli/src/main/java/io/codiga/cli/model/sarif/SarifReplacement.java
+++ b/cli/src/main/java/io/codiga/cli/model/sarif/SarifReplacement.java
@@ -9,6 +9,11 @@ import java.util.Optional;
 import static io.codiga.model.error.EditType.ADD;
 import static io.codiga.model.error.EditType.UPDATE;
 
+/**
+ * The replacement of a single region of an artifact.
+ * <br>
+ * <a href="https://github.com/DataDog/datadog-ci/blob/master/src/commands/sarif/json-schema/sarif-schema-2.1.0.json#L1789">See in the SARIF JSON Schema</a>
+ */
 @Builder
 public class SarifReplacement {
     // The region of the artifact to delete.

--- a/cli/src/main/java/io/codiga/cli/model/sarif/SarifReport.java
+++ b/cli/src/main/java/io/codiga/cli/model/sarif/SarifReport.java
@@ -10,6 +10,11 @@ import java.util.List;
 
 import static io.codiga.cli.utils.SarifUtils.SARIF_VERSION;
 
+/**
+ * The standard format for the output of static analysis tools.
+ * <br>
+ * <a href="https://github.com/DataDog/datadog-ci/blob/master/src/commands/sarif/json-schema/sarif-schema-2.1.0.json#L8">See in the SARIF JSON Schema</a>
+ */
 @Builder
 public class SarifReport {
     public String version;

--- a/cli/src/main/java/io/codiga/cli/model/sarif/SarifResult.java
+++ b/cli/src/main/java/io/codiga/cli/model/sarif/SarifResult.java
@@ -7,6 +7,11 @@ import java.util.List;
 
 import static io.codiga.cli.utils.SarifUtils.severityToSarifLevel;
 
+/**
+ * A result produced by an analysis tool.
+ * <br>
+ * <a href="https://github.com/DataDog/datadog-ci/blob/master/src/commands/sarif/json-schema/sarif-schema-2.1.0.json#L2038">See in the SARIF JSON Schema</a>
+ */
 @Builder
 public class SarifResult {
     public String level;

--- a/cli/src/main/java/io/codiga/cli/model/sarif/SarifResultArtifactLocation.java
+++ b/cli/src/main/java/io/codiga/cli/model/sarif/SarifResultArtifactLocation.java
@@ -6,6 +6,11 @@ import java.nio.file.Path;
 
 import static io.codiga.cli.utils.SarifUtils.stripLeadingSlash;
 
+/**
+ * Specifies the location of an artifact.
+ * <br>
+ * <a href="https://github.com/DataDog/datadog-ci/blob/master/src/commands/sarif/json-schema/sarif-schema-2.1.0.json#L289">See in the SARIF JSON Schema</a>
+ */
 @Builder
 public class SarifResultArtifactLocation {
     public String uri;

--- a/cli/src/main/java/io/codiga/cli/model/sarif/SarifResultFix.java
+++ b/cli/src/main/java/io/codiga/cli/model/sarif/SarifResultFix.java
@@ -5,6 +5,13 @@ import lombok.Builder;
 
 import java.util.List;
 
+/**
+ * A proposed fix for the problem represented by a result object.
+ * A fix specifies a set of artifacts to modify.
+ * For each artifact, it specifies a set of bytes to remove, edit, or add and provides a set of new bytes to replace them.
+ * <br>
+ * <a href="https://github.com/DataDog/datadog-ci/blob/master/src/commands/sarif/json-schema/sarif-schema-2.1.0.json#L978">See in the SARIF JSON Schema</a>
+ */
 @Builder
 public class SarifResultFix {
     public SarifResultMessage description;
@@ -14,7 +21,8 @@ public class SarifResultFix {
     public static SarifResultFix generate(Fix fix, String filename) {
         return SarifResultFix
             .builder()
-            .description(SarifResultMessage.builder().text(fix.description).build())
+            .description(new SarifResultMessage(fix.description))
+//            .description(SarifResultMessage.builder().text(fix.description).build())
             .artifactChanges(fix.edits == null ? List.of() : List.of(SarifArtifactChange.generate(fix, filename)))
             .build();
     }

--- a/cli/src/main/java/io/codiga/cli/model/sarif/SarifResultLocation.java
+++ b/cli/src/main/java/io/codiga/cli/model/sarif/SarifResultLocation.java
@@ -3,6 +3,11 @@ package io.codiga.cli.model.sarif;
 import io.codiga.cli.model.ViolationWithFilename;
 import lombok.Builder;
 
+/**
+ * A location within a programming artifact.
+ * <br>
+ * <a href="https://github.com/DataDog/datadog-ci/blob/master/src/commands/sarif/json-schema/sarif-schema-2.1.0.json#L1291">See in the SARIF JSON Schema</a>
+ */
 @Builder
 public class SarifResultLocation {
     public SarifResultPhysicalLocation physicalLocation;

--- a/cli/src/main/java/io/codiga/cli/model/sarif/SarifResultMessage.java
+++ b/cli/src/main/java/io/codiga/cli/model/sarif/SarifResultMessage.java
@@ -2,6 +2,11 @@ package io.codiga.cli.model.sarif;
 
 import lombok.Builder;
 
+/**
+ * Encapsulates a message intended to be read by the end user.
+ * <br>
+ * <a href="https://github.com/DataDog/datadog-ci/blob/master/src/commands/sarif/json-schema/sarif-schema-2.1.0.json#L1436">See in the SARIF JSON Schema</a>
+ */
 @Builder
 public class SarifResultMessage {
     public String text;

--- a/cli/src/main/java/io/codiga/cli/model/sarif/SarifResultPhysicalLocation.java
+++ b/cli/src/main/java/io/codiga/cli/model/sarif/SarifResultPhysicalLocation.java
@@ -3,6 +3,12 @@ package io.codiga.cli.model.sarif;
 import io.codiga.cli.model.ViolationWithFilename;
 import lombok.Builder;
 
+/**
+ * A physical location relevant to a result.
+ * Specifies a reference to a programming artifact together with a range of bytes or characters within that artifact.
+ * <br>
+ * <a href="https://github.com/DataDog/datadog-ci/blob/master/src/commands/sarif/json-schema/sarif-schema-2.1.0.json#L1613">See in the SARIF JSON Schema</a>
+ */
 @Builder
 public class SarifResultPhysicalLocation {
     public SarifResultArtifactLocation artifactLocation;

--- a/cli/src/main/java/io/codiga/cli/model/sarif/SarifRun.java
+++ b/cli/src/main/java/io/codiga/cli/model/sarif/SarifRun.java
@@ -8,6 +8,11 @@ import lombok.Builder;
 import java.nio.file.Path;
 import java.util.List;
 
+/**
+ * Describes a single run of an analysis tool, and contains the reported output of that run.
+ * <br>
+ * <a href="https://github.com/DataDog/datadog-ci/blob/master/src/commands/sarif/json-schema/sarif-schema-2.1.0.json#L2339">See in the SARIF JSON Schema</a>
+ */
 @Builder
 public class SarifRun {
     public SarifTool tool;

--- a/cli/src/main/java/io/codiga/cli/model/sarif/SarifTool.java
+++ b/cli/src/main/java/io/codiga/cli/model/sarif/SarifTool.java
@@ -5,6 +5,11 @@ import lombok.Builder;
 
 import java.util.List;
 
+/**
+ * The analysis tool that was run.
+ * <br>
+ * <a href="https://github.com/DataDog/datadog-ci/blob/master/src/commands/sarif/json-schema/sarif-schema-2.1.0.json#L2910">See in the SARIF JSON Schema</a>
+ */
 @Builder
 public class SarifTool {
     public SarifToolDriver driver;

--- a/cli/src/main/java/io/codiga/cli/model/sarif/SarifToolDriver.java
+++ b/cli/src/main/java/io/codiga/cli/model/sarif/SarifToolDriver.java
@@ -5,6 +5,11 @@ import lombok.Builder;
 
 import java.util.List;
 
+/**
+ * The driver of the analysis tool that was run.
+ * <br>
+ * <a href="https://github.com/DataDog/datadog-ci/blob/master/src/commands/sarif/json-schema/sarif-schema-2.1.0.json#L2941">See in the SARIF JSON Schema</a>
+ */
 @Builder
 public class SarifToolDriver {
     public String name;

--- a/cli/src/main/java/io/codiga/cli/model/sarif/SarifToolDriverRule.java
+++ b/cli/src/main/java/io/codiga/cli/model/sarif/SarifToolDriverRule.java
@@ -3,6 +3,11 @@ package io.codiga.cli.model.sarif;
 import io.codiga.analyzer.rule.AnalyzerRule;
 import lombok.Builder;
 
+/**
+ * Metadata that describes a specific report produced by the tool, as part of the analysis it provides or its runtime reporting.
+ * <br>
+ * <a href="https://github.com/DataDog/datadog-ci/blob/master/src/commands/sarif/json-schema/sarif-schema-2.1.0.json#L1814">See in the SARIF JSON Schema</a>
+ */
 @Builder
 public class SarifToolDriverRule {
     public String id;


### PR DESCRIPTION
#### What problem are we trying to solve?

It's difficult to review and compare SARIF classes with the JSON schema counterpart.

#### Solution

Add direct links to the schema location for each class and included the description as well.
