### PR TITLE
Add tag to specify the kind of edit

### DIFF
--- a/cli/src/main/java/io/codiga/cli/Main.java
+++ b/cli/src/main/java/io/codiga/cli/Main.java
@@ -219,6 +219,7 @@ public class Main {
                                 return ViolationWithFilename.builder()
                                     .start(violation.start)
                                     .end(violation.end)
+                                    .rule(ruleResult.identifier())
                                     .message(violation.message)
                                     .severity(violation.severity)
                                     .category(violation.category)

--- a/cli/src/main/java/io/codiga/cli/model/ViolationWithFilename.java
+++ b/cli/src/main/java/io/codiga/cli/model/ViolationWithFilename.java
@@ -17,5 +17,7 @@ public class ViolationWithFilename {
     public Category category;
     public String filename;
     public String rule;
+
+    @Builder.Default
     public List<Fix> fixes = List.of();
 }

--- a/cli/src/main/java/io/codiga/cli/model/sarif/SarifPropertyBag.java
+++ b/cli/src/main/java/io/codiga/cli/model/sarif/SarifPropertyBag.java
@@ -1,0 +1,16 @@
+package io.codiga.cli.model.sarif;
+
+import lombok.Builder;
+
+import java.util.List;
+
+/**
+ * Properties being added to an object
+ * <br>
+ * <a href="https://github.com/DataDog/datadog-ci/blob/master/src/commands/sarif/json-schema/sarif-schema-2.1.0.json#L1654">See in the SARIF JSON Schema</a>
+ */
+@Builder
+public class SarifPropertyBag {
+    @Builder.Default
+    public List<String> tags = List.of();
+}

--- a/cli/src/main/java/io/codiga/cli/model/sarif/SarifReplacement.java
+++ b/cli/src/main/java/io/codiga/cli/model/sarif/SarifReplacement.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import io.codiga.model.error.Edit;
 import lombok.Builder;
 
+import java.util.List;
 import java.util.Optional;
 
 import static io.codiga.model.error.EditType.ADD;
@@ -21,6 +22,7 @@ public class SarifReplacement {
     // The content to insert at the location specified by the 'deletedRegion' property.
     @JsonInclude(JsonInclude.Include.NON_NULL)
     public SarifArtifactContent insertedContent;
+    public SarifPropertyBag properties;
 
     public static Optional<SarifReplacement> generate(Edit edit) {
         Optional<SarifRegion> deleteRegion = getRegionForDeleteRegion(edit);
@@ -28,7 +30,21 @@ public class SarifReplacement {
             .builder()
             .deletedRegion(sarifRegion)
             .insertedContent(getContentToInsert(edit))
+            .properties(SarifPropertyBag.builder().tags(List.of(generateRosieEditTag(edit))).build())
             .build());
+    }
+
+    /**
+     * The tag added is to indicate in the SARIF format if the edit is an add, update or remove.
+     * This function generates the tag.
+     * <p>
+     * The tag is in the form rosieEditType:ADD
+     *
+     * @param edit - the edit for the tag
+     * @return a string that represents the tag we are generating
+     */
+    public static String generateRosieEditTag(Edit edit) {
+        return String.format("rosieEditType:%s", edit.editType.toString().toUpperCase());
     }
 
     public static Optional<SarifRegion> getRegionForDeleteRegion(Edit edit) {

--- a/cli/src/main/java/io/codiga/cli/model/sarif/SarifResultFix.java
+++ b/cli/src/main/java/io/codiga/cli/model/sarif/SarifResultFix.java
@@ -22,7 +22,6 @@ public class SarifResultFix {
         return SarifResultFix
             .builder()
             .description(new SarifResultMessage(fix.description))
-//            .description(SarifResultMessage.builder().text(fix.description).build())
             .artifactChanges(fix.edits == null ? List.of() : List.of(SarifArtifactChange.generate(fix, filename)))
             .build();
     }


### PR DESCRIPTION
**What problem are you trying to solve?**

We want to indicate the type of edit from Codiga in SARIF.

**Solution**

For an `replacement`, generate a `rosieEditType` to indicate the type of replacement (add, remove, update).

**Notes**
 - Also ensure that the rule id is added when processing rules
 - Make sure that elements in classes that use the `@Builder` decorator that need to be initialized have the decorator `@Builder.Default`

