### PR TITLE
[STAT-46] add ignore directories to CLI

### DIFF
--- a/cli/src/main/java/io/codiga/cli/model/Result.java
+++ b/cli/src/main/java/io/codiga/cli/model/Result.java
@@ -1,10 +1,9 @@
 package io.codiga.cli.model;
 
 import io.codiga.model.error.RuleResult;
-import java.util.List;
-import lombok.NoArgsConstructor;
 
-@NoArgsConstructor
+import java.util.List;
+
 public class Result {
     public List<ViolationWithFilename> violations;
     public List<RuleResult> ruleResultsWithError;

--- a/cli/src/main/java/io/codiga/cli/model/ViolationWithFilename.java
+++ b/cli/src/main/java/io/codiga/cli/model/ViolationWithFilename.java
@@ -4,13 +4,10 @@ import io.codiga.model.common.Position;
 import io.codiga.model.error.Category;
 import io.codiga.model.error.Fix;
 import io.codiga.model.error.Severity;
-import java.util.List;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.NoArgsConstructor;
 
-@NoArgsConstructor
-@AllArgsConstructor
+import java.util.List;
+
 @Builder
 public class ViolationWithFilename {
     public Position start;

--- a/core/src/main/java/io/codiga/model/error/Edit.java
+++ b/core/src/main/java/io/codiga/model/error/Edit.java
@@ -1,9 +1,8 @@
 package io.codiga.model.error;
 
 import io.codiga.model.common.Position;
-import lombok.NoArgsConstructor;
 
-@NoArgsConstructor
+
 public class Edit {
     public Position start;
     public Position end;

--- a/core/src/main/java/io/codiga/model/error/Fix.java
+++ b/core/src/main/java/io/codiga/model/error/Fix.java
@@ -2,9 +2,8 @@ package io.codiga.model.error;
 
 
 import java.util.List;
-import lombok.NoArgsConstructor;
 
-@NoArgsConstructor
+
 public class Fix {
     public String description;
     public List<Edit> edits;


### PR DESCRIPTION
#### What problem are you trying to solve?

There's a new field in our config file, `ignorePaths`, that the CLI doesn't support yet. 

```yaml
rulesets:
  - python-security
ignorePaths: 
  - some/path/to/ignore   <-- this
```

#### Solution

Add an `ignore-path` option to the CLI that can accept multiple paths

```
--ignore-path foo --ignore-path bar/baz/*.py
```

#### Notes

- Updated `rules.json` as some of the rules have changed and the previous didn't work
- I committed the reformatting of `Main.java` separately, so I'd suggest reviewing `Main.java` with this [separate commit](https://github.com/codiga/rosie/commit/b70fb69ceef4dc88591210831de93dba5bbdb9af) which has the new additions 
- Added some constructor annotations to multiple Model classes to be able to test the CLI output
- Added a `test-mode` option to the CLI to be able to test the CLI output