### PR TITLE
[STAT-96] Fix URL to invoke Rulesets public API.

### DIFF
--- a/cli/src/main/java/io/codiga/cli/utils/DatadogUtils.java
+++ b/cli/src/main/java/io/codiga/cli/utils/DatadogUtils.java
@@ -21,7 +21,7 @@ import java.util.Optional;
 
 public class DatadogUtils {
 
-    public final static String DEFAULT_SITE = "app.datadoghq.com";
+    public final static String DEFAULT_SITE = "datadoghq.com";
 
     /**
      * Decode a rule from JSON. If the mapping does not work, return Optional.empty()
@@ -121,7 +121,7 @@ public class DatadogUtils {
 
 
             var request = HttpRequest.newBuilder(
-                    URI.create(String.format("https://%s/api/v2/static-analysis/rulesets/%s", site, ruleset)))
+                    URI.create(String.format("https://api.%s/api/v2/static-analysis/rulesets/%s", site, ruleset)))
                 .header("accept", "application/json")
                 .header("dd-api-key", apiKey.get())
                 .header("dd-application-key", appKey.get())


### PR DESCRIPTION
This PR fixes the endpoint to use in the calls to the Public API implemented [in this PR](https://github.com/DataDog/rosie/pull/30)

The reason behind is the `DD_SITE` env var does not contain this prefix. (E.g., `DD_SITE:datadoghq.com`)

Tested already using the `DD_SITE=datad0g.com`
[Link](https://dd.datad0g.com/ci/static-analysis?query=%40static_analysis.result.status%3A%2A&currentTab=source-code&index=cicodescan&staticAnalysisId=AgAAAYgGDdwuDDb9nAAAAAAAAAAYAAAAAEFZZ0dEZGNRQUFEX3ZZWE11dmZjQUFBQQAAACQAAAAAMDE4ODA2MGQtZGMyZS00NzljLTkxOTMtNTljMzAzNDU0MThl&trace=AgAAAYgGDdwuDDb9nAAAAAAAAAAYAAAAAEFZZ0dEZGNRQUFEX3ZZWE11dmZjQUFBQQAAACQAAAAAMDE4ODA2MGQtZGMyZS00NzljLTkxOTMtNTljMzAzNDU0MThl&start=1683123969619&end=1683728769619&paused=false)