### PR TITLE
[STAT-105] Add description to the Analyzer Rule

### DIFF
--- a/cli/src/main/java/io/codiga/cli/model/sarif/SarifMultiformatMessage.java
+++ b/cli/src/main/java/io/codiga/cli/model/sarif/SarifMultiformatMessage.java
@@ -1,0 +1,23 @@
+package io.codiga.cli.model.sarif;
+
+import lombok.Builder;
+
+import java.util.Base64;
+
+/**
+ * Encapsulates a multiformat message intended to be read by the end user.
+ * <br>
+ * <a href="https://github.com/DataDog/datadog-ci/blob/master/src/commands/sarif/json-schema/sarif-schema-2.1.0.json#L1483-L1506">See in the SARIF JSON Schema</a>
+ */
+@Builder
+public class SarifMultiformatMessage {
+    public String text;
+
+    public static SarifMultiformatMessage from(String str) {
+        if(str == null || str.length() == 0){
+            return null;
+        }
+
+        return SarifMultiformatMessage.builder().text(new String(Base64.getDecoder().decode(str.getBytes()))).build();
+    }
+}

--- a/cli/src/main/java/io/codiga/cli/model/sarif/SarifToolDriverRule.java
+++ b/cli/src/main/java/io/codiga/cli/model/sarif/SarifToolDriverRule.java
@@ -1,5 +1,6 @@
 package io.codiga.cli.model.sarif;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import io.codiga.analyzer.rule.AnalyzerRule;
 import lombok.Builder;
 
@@ -11,11 +12,14 @@ import lombok.Builder;
 @Builder
 public class SarifToolDriverRule {
     public String id;
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public SarifMultiformatMessage fullDescription;
     public String helpUri;
 
     public static SarifToolDriverRule fromAnalyzerRule(AnalyzerRule analyzerRule) {
         return SarifToolDriverRule
                 .builder()
+                .fullDescription(SarifMultiformatMessage.from(analyzerRule.description()))
                 .helpUri(String.format("https://static-analysis.datadoghq.com/%s", analyzerRule.name()))
                 .id(analyzerRule.name())
                 .build();

--- a/cli/src/main/java/io/codiga/cli/utils/DatadogUtils.java
+++ b/cli/src/main/java/io/codiga/cli/utils/DatadogUtils.java
@@ -47,7 +47,7 @@ public class DatadogUtils {
             if (code != null) {
                 String decodedCode = new String(Base64.getDecoder().decode(code));
                 return Optional.of(
-                    new AnalyzerRule(String.format("%s/%s", rulesetName, res.name()), res.language(), res.ruleType(), res.entityChecked(), decodedCode, res.pattern(), res.treeSitterQuery(), res.variables())
+                    new AnalyzerRule(String.format("%s/%s", rulesetName, res.name()), res.description(), res.language(), res.ruleType(), res.entityChecked(), decodedCode, res.pattern(), res.treeSitterQuery(), res.variables())
                 );
             }
         } catch (IllegalArgumentException e) {

--- a/cli/src/main/java/io/codiga/cli/utils/RulesUtils.java
+++ b/cli/src/main/java/io/codiga/cli/utils/RulesUtils.java
@@ -19,7 +19,8 @@ public class RulesUtils {
         ObjectMapper mapper = new ObjectMapper();
         return mapper.readValue(new File(path), Rules.class).rules.stream().map(r -> {
             String decodedCode = new String(Base64.getDecoder().decode(r.code()));
-            return new AnalyzerRule(r.name(), r.language(), r.ruleType(), r.entityChecked(), decodedCode, r.pattern(), r.treeSitterQuery(), r.variables());
+            String decodedDescription = r.description() != null ? new String(Base64.getDecoder().decode(r.description())):"";
+            return new AnalyzerRule(r.name(), decodedDescription, r.language(), r.ruleType(), r.entityChecked(), decodedCode, r.pattern(), r.treeSitterQuery(), r.variables());
         }).collect(Collectors.toList());
     }
 

--- a/cli/src/test/java/io/codiga/cli/utils/SarifUtilsTest.java
+++ b/cli/src/test/java/io/codiga/cli/utils/SarifUtilsTest.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Test;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.util.Base64;
 import java.util.List;
 import java.util.Map;
 import java.util.logging.Logger;
@@ -31,6 +32,7 @@ import static org.junit.jupiter.api.Assertions.*;
 public class SarifUtilsTest {
 
     private static final String SARIF_SCHEMA_PATH = "src/test/resources/sarif-standard/sarif-schema-2.1.0.json";
+    private static final String ENCODED_DESCRIPTION = new String(Base64.getEncoder().encode("myruledescription".getBytes()));
     private final Logger log = Logger.getLogger("Test");
 
     @BeforeAll
@@ -83,7 +85,7 @@ public class SarifUtilsTest {
 
         assertTrue(checkCompliance(
             generateReport(
-                List.of(new AnalyzerRule("myrule", Language.PYTHON, RuleType.AST_CHECK, EntityChecked.ASSIGNMENT, "code", null, null, Map.of())),
+                List.of(new AnalyzerRule("myrule", ENCODED_DESCRIPTION, Language.PYTHON, RuleType.AST_CHECK, EntityChecked.ASSIGNMENT, "code", null, null, Map.of())),
                 List.of(new File("foo/bar").toPath()),
                 List.of(violation),
                 List.of())));
@@ -108,7 +110,7 @@ public class SarifUtilsTest {
 
         assertTrue(checkCompliance(
             generateReport(
-                List.of(new AnalyzerRule("myrule", Language.PYTHON, RuleType.AST_CHECK, EntityChecked.ASSIGNMENT, "code", null, null, Map.of())),
+                List.of(new AnalyzerRule("myrule", ENCODED_DESCRIPTION, Language.PYTHON, RuleType.AST_CHECK, EntityChecked.ASSIGNMENT, "code", null, null, Map.of())),
                 List.of(new File("foo/bar").toPath()),
                 List.of(violation),
                 List.of())));
@@ -133,7 +135,7 @@ public class SarifUtilsTest {
 
         assertTrue(checkCompliance(
             generateReport(
-                List.of(new AnalyzerRule("myrule", Language.PYTHON, RuleType.AST_CHECK, EntityChecked.ASSIGNMENT, "code", null, null, Map.of())),
+                List.of(new AnalyzerRule("myrule",ENCODED_DESCRIPTION, Language.PYTHON, RuleType.AST_CHECK, EntityChecked.ASSIGNMENT, "code", null, null, Map.of())),
                 List.of(new File("foo/bar").toPath()),
                 List.of(violation),
                 List.of())));
@@ -172,14 +174,16 @@ public class SarifUtilsTest {
 
         SarifReport sarifReport = generateReport(
             List.of(
-                new AnalyzerRule("myrule1", Language.PYTHON, RuleType.AST_CHECK, EntityChecked.ASSIGNMENT, "code", null, null, Map.of()),
-                new AnalyzerRule("myrule2", Language.PYTHON, RuleType.AST_CHECK, EntityChecked.ASSIGNMENT, "code", null, null, Map.of())),
+                new AnalyzerRule("myrule1",ENCODED_DESCRIPTION, Language.PYTHON, RuleType.AST_CHECK, EntityChecked.ASSIGNMENT, "code", null, null, Map.of()),
+                new AnalyzerRule("myrule2",ENCODED_DESCRIPTION, Language.PYTHON, RuleType.AST_CHECK, EntityChecked.ASSIGNMENT, "code", null, null, Map.of())),
             List.of(new File("foo/bar").toPath()),
             List.of(violation1, violation2),
             List.of());
 
         assertEquals("myrule1", sarifReport.runs.get(0).tool.driver.rules.get(0).id);
+        assertEquals("myruledescription", sarifReport.runs.get(0).tool.driver.rules.get(0).fullDescription.text);
         assertEquals("myrule2", sarifReport.runs.get(0).tool.driver.rules.get(1).id);
+        assertEquals("myruledescription", sarifReport.runs.get(0).tool.driver.rules.get(1).fullDescription.text);
 
         assertEquals("myrule2", sarifReport.runs.get(0).results.get(0).ruleId);
         assertEquals(1, sarifReport.runs.get(0).results.get(0).ruleIndex);
@@ -209,7 +213,7 @@ public class SarifUtilsTest {
 
         assertTrue(checkCompliance(
             generateReport(
-                List.of(new AnalyzerRule("myrule", Language.PYTHON, RuleType.AST_CHECK, EntityChecked.ASSIGNMENT, "code", null, null, Map.of())),
+                List.of(new AnalyzerRule("myrule",ENCODED_DESCRIPTION, Language.PYTHON, RuleType.AST_CHECK, EntityChecked.ASSIGNMENT, "code", null, null, Map.of())),
                 List.of(new File("foo/bar").toPath()),
                 List.of(violation),
                 List.of())));
@@ -230,7 +234,7 @@ public class SarifUtilsTest {
 
         assertFalse(checkCompliance(
             generateReport(
-                List.of(new AnalyzerRule("myrule", Language.PYTHON, RuleType.AST_CHECK, EntityChecked.ASSIGNMENT, "code", null, null, Map.of())),
+                List.of(new AnalyzerRule("myrule", ENCODED_DESCRIPTION, Language.PYTHON, RuleType.AST_CHECK, EntityChecked.ASSIGNMENT, "code", null, null, Map.of())),
                 List.of(new File("foo/bar").toPath()),
                 List.of(violation),
                 List.of())));

--- a/cli/src/test/resources/1rule.json
+++ b/cli/src/test/resources/1rule.json
@@ -2,6 +2,7 @@
   "rules": [
     {
       "name": "myrule/bla",
+      "description": "bXlydWxlZGVzY3JpcHRpb24=",
       "language": "PYTHON",
       "ruleType": "AST_CHECK",
       "entityChecked": "FUNCTION_CALL",

--- a/core/src/main/java/io/codiga/analyzer/rule/AnalyzerRule.java
+++ b/core/src/main/java/io/codiga/analyzer/rule/AnalyzerRule.java
@@ -6,6 +6,7 @@ import io.codiga.model.RuleType;
 import java.util.Map;
 
 public record AnalyzerRule(String name,
+                           String description,
                            Language language,
                            RuleType ruleType,
                            EntityChecked entityChecked, // defined/used only when ruleType is an AST rule

--- a/core/src/main/java/io/codiga/warmup/AnalyzerWarmup.java
+++ b/core/src/main/java/io/codiga/warmup/AnalyzerWarmup.java
@@ -43,6 +43,7 @@ public class AnalyzerWarmup {
                                     .map(analyzerRule ->
                                             new AnalyzerRule(
                                                     analyzerRule.name(),
+                                                    analyzerRule.description(),
                                                     analyzerRule.language(),
                                                     analyzerRule.ruleType(),
                                                     analyzerRule.entityChecked(),

--- a/core/src/main/java/io/codiga/warmup/AnalyzerWarmupCode.java
+++ b/core/src/main/java/io/codiga/warmup/AnalyzerWarmupCode.java
@@ -17,6 +17,7 @@ public class AnalyzerWarmupCode {
             .setAnalyzerRuleList(
                 List.of(new AnalyzerRule(
                     "raising-not-implemented",
+                    "raising-not-implemented description",
                     Language.PYTHON,
                     RuleType.PATTERN,
                     null,
@@ -33,6 +34,7 @@ public class AnalyzerWarmupCode {
             .setAnalyzerRuleList(
                 List.of(new AnalyzerRule(
                     "no-eval",
+                    "no-eval description",
                     Language.PYTHON,
                     RuleType.AST_CHECK,
                     EntityChecked.FUNCTION_CALL,
@@ -49,6 +51,7 @@ public class AnalyzerWarmupCode {
             .setAnalyzerRuleList(
                 List.of(new AnalyzerRule(
                     "no-timeout",
+                    "no-timeout description",
                     Language.PYTHON,
                     RuleType.AST_CHECK,
                     EntityChecked.FUNCTION_CALL,
@@ -65,6 +68,7 @@ public class AnalyzerWarmupCode {
             .setAnalyzerRuleList(
                 List.of(new AnalyzerRule(
                     "subprocess-shell-true",
+                    "subprocess-shell-true description",
                     Language.PYTHON,
                     RuleType.AST_CHECK,
                     EntityChecked.FUNCTION_CALL,

--- a/core/src/test/java/io/codiga/analyzer/pattern/PatternMatcherTest.java
+++ b/core/src/test/java/io/codiga/analyzer/pattern/PatternMatcherTest.java
@@ -46,7 +46,7 @@ public class PatternMatcherTest extends PythonTestUtils {
     @DisplayName("Extract the variables from the pattern")
     public void testVariablesExtraction() {
         String pattern = "open(${file}, \"r\")";
-        AnalyzerRule rule = new AnalyzerRule("myrule", Language.PYTHON, RuleType.PATTERN, null, ruleCode, pattern, null, null);
+        AnalyzerRule rule = new AnalyzerRule("myrule", "myruledescription", Language.PYTHON, RuleType.PATTERN, null, ruleCode, pattern, null, null);
         PatternMatcher patternMatcher = new PatternMatcher(code, rule);
 
         List<PatternVariable> variables = patternMatcher.getVariablesFromPattern(pattern);
@@ -60,7 +60,7 @@ public class PatternMatcherTest extends PythonTestUtils {
     @DisplayName("Correctly transform the pattern into regular expression")
     public void testRegularExpressionGeneration() {
         String pattern = "open(${file}, \"${mode}\")";
-        AnalyzerRule rule = new AnalyzerRule("myrule", Language.PYTHON, RuleType.PATTERN, null, ruleCode, pattern, null, null);
+        AnalyzerRule rule = new AnalyzerRule("myrule","myruledescription", Language.PYTHON, RuleType.PATTERN, null, ruleCode, pattern, null, null);
         PatternMatcher patternMatcher = new PatternMatcher(code, rule);
 
         List<PatternVariable> variables = patternMatcher.getVariablesFromPattern(pattern);
@@ -72,7 +72,7 @@ public class PatternMatcherTest extends PythonTestUtils {
     public void testPatternObjectOneLine() {
         String pattern = "open(${file}, \"${mode}\")";
         String localCode = "open(\"foo\", \"r\")";
-        AnalyzerRule rule = new AnalyzerRule("myrule", Language.PYTHON, RuleType.PATTERN, null, ruleCode, pattern, null, null);
+        AnalyzerRule rule = new AnalyzerRule("myrule","myruledescription", Language.PYTHON, RuleType.PATTERN, null, ruleCode, pattern, null, null);
         PatternMatcher patternMatcher = new PatternMatcher(localCode, rule);
         List<PatternObject> patternObjects = patternMatcher.getPatternObjects();
         assertEquals(patternObjects.size(), 1);
@@ -101,7 +101,7 @@ public class PatternMatcherTest extends PythonTestUtils {
     public void testPatternObjectTwoLines() {
         String pattern = "open(${file}, \"${mode}\")";
         String localCode = "bla\nbli open(\"foo\", \"r\")";
-        AnalyzerRule rule = new AnalyzerRule("myrule", Language.PYTHON, RuleType.PATTERN, null, ruleCode, pattern, null, null);
+        AnalyzerRule rule = new AnalyzerRule("myrule","myruledescription", Language.PYTHON, RuleType.PATTERN, null, ruleCode, pattern, null, null);
         PatternMatcher patternMatcher = new PatternMatcher(localCode, rule);
         List<PatternObject> patternObjects = patternMatcher.getPatternObjects();
         assertEquals(1, patternObjects.size());

--- a/server/src/main/java/io/codiga/server/ServerMainController.java
+++ b/server/src/main/java/io/codiga/server/ServerMainController.java
@@ -155,7 +155,12 @@ public class ServerMainController {
                         Language language = languageFromString(r.language);
                         EntityChecked entityChecked = entityCheckedFromString(r.entityChecked);
                         RuleType ruleType = ruleTypeFromString(r.type);
-                        return new AnalyzerRule(r.id, language, ruleType, entityChecked, decodedRuleCode, r.pattern, tsQuery, r.variables);
+
+                        String description = null;
+                        if (r.description != null) {
+                            description = new String(Base64.getDecoder().decode(r.description.getBytes()));
+                        }
+                        return new AnalyzerRule(r.id, description, language, ruleType, entityChecked, decodedRuleCode, r.pattern, tsQuery, r.variables);
                     }).toList();
         } catch (IllegalArgumentException iae) {
             logger.error("rule is not base64: " + request.rules);

--- a/server/src/main/java/io/codiga/server/request/Rule.java
+++ b/server/src/main/java/io/codiga/server/request/Rule.java
@@ -4,6 +4,7 @@ import java.util.Map;
 
 public class Rule {
     public String id;
+    public String description;
     public String contentBase64;
     public String language;
     public String type;
@@ -17,6 +18,7 @@ public class Rule {
     }
 
     public Rule(String id,
+                String description,
                 String language,
                 String type,
                 String entityChecked,
@@ -25,6 +27,7 @@ public class Rule {
                 String contentBase64,
                 Map<String, String> variables) {
         this.id = id;
+        this.description = description;
         this.contentBase64 = contentBase64;
         this.language = language;
         this.type = type;
@@ -35,6 +38,6 @@ public class Rule {
     }
 
     public String toString() {
-        return String.format("%s %s %s %s %s %s", id, language, type, entityChecked, pattern, variables);
+        return String.format("%s %s %s %s %s %s %s", id, description, language, type, entityChecked, pattern, variables);
     }
 }

--- a/server/src/main/java/io/codiga/server/request/RuleBuilder.java
+++ b/server/src/main/java/io/codiga/server/request/RuleBuilder.java
@@ -4,6 +4,7 @@ import java.util.Map;
 
 public class RuleBuilder {
     private String id;
+    private String description;
     private String language;
     private String type;
     private String entityChecked;
@@ -14,6 +15,11 @@ public class RuleBuilder {
 
     public RuleBuilder setId(String id) {
         this.id = id;
+        return this;
+    }
+
+    public RuleBuilder setDescription(String description) {
+        this.description = description;
         return this;
     }
 
@@ -53,6 +59,6 @@ public class RuleBuilder {
     }
 
     public Rule createRule() {
-        return new Rule(id, language, type, entityChecked, tsQueryBase64, pattern, contentBase64, variables);
+        return new Rule(id, description, language, type, entityChecked, tsQueryBase64, pattern, contentBase64, variables);
     }
 }


### PR DESCRIPTION
#### What problem are you trying to solve?

Expose the rule description in the SARIF report.

#### Solution

Extend the `AnalyzerRule` model to kept the description in it. This is the class that is used to generate the SARIF report.

#### Notes

* This PR also adds the description to the rule in the SARIF report.

[Tested in staging](https://dd.datad0g.com/ci/static-analysis?query=%40static_analysis.result.status%3A%2A&currentTab=event&index=cicodescan&staticAnalysisId=AgAAAYgQImK4Thf9lwAAAAAAAAAYAAAAAEFZZ1FJbHZGQUFDdnJHdGp2VklOQUFBQQAAACQAAAAAMDE4ODEwMjItNjJiOC00NWIxLWFjMWQtMzg1MDBkZmY2Y2Q2&trace=AgAAAYgQImK4Thf9lwAAAAAAAAAYAAAAAEFZZ1FJbHZGQUFDdnJHdGp2VklOQUFBQQAAACQAAAAAMDE4ODEwMjItNjJiOC00NWIxLWFjMWQtMzg1MDBkZmY2Y2Q2&start=1683896078036&end=1683897878036&paused=false)

<img width="737" alt="image" src="https://github.com/DataDog/rosie/assets/29516565/4517df0f-8944-4599-bf8b-251093337f2c">

