### PR TITLE
add k8s folder to add CNAB deployment

### DIFF
--- a/config/k8s/BUILD.bazel
+++ b/config/k8s/BUILD.bazel
@@ -1,0 +1,65 @@
+load("@com_datadoghq_cnab_tools//rules:helm.bzl", "helm_chart", "helm_cnab_installation")
+load("@com_datadoghq_cnab_tools//rules:workflow.bzl", "cnab_workflow")
+load("@com_datadoghq_datacenter_config//rules:helm.bzl", "dd_helm_cnab", "dd_helm_cnab_installation")
+load("@com_datadoghq_cnab_tools//rules/artifact:artifact_docker.bzl", "dd_container_push")
+load("@com_datadoghq_cnab_tools//rules:cli_defaults.bzl", "REGISTRY")
+
+team_domain = "static-analysis"
+
+# Define the Helm chart
+helm_chart(
+    name = "chart",
+    srcs = [
+        "Chart.yaml",
+        "values.yaml",
+        "templates/_helpers.tpl",
+        "templates/deployment.yaml",
+        "templates/nodegroup.yaml",
+    ],
+)
+
+# Define the application bundle
+dd_helm_cnab(
+    name = "rosie",
+    # The helm chart to be installed
+    chart = ":chart",
+    registry = REGISTRY,
+    # "repository" is a namespace given to an individual artifact that contains
+    # multiple versions of that artifact referenced by digest or tag
+    # Change my-repo to the name of your repository
+    repository = "rosie",
+    visibility = ["//visibility:public"],
+    with_datacenter_helm_files = False,
+)
+
+default_params = {
+    "manualJudgementSlackChannel": "static-analysis-prod",
+    # Automatically annotate for Datadog tag autodiscovery
+    "injectInstallationNameInMetrics": "true",
+    "injectCNABRevisionInMetrics": "true",
+    "dangerouslyDisableDiffPrompt": "false",
+}
+
+dd_helm_cnab_installation(
+    name = "rosie.delivery-platform.general1.us1.ddbuild.io",
+    bundle = ":rosie",
+    description = "Rosie Pause instance",
+    parameters = default_params,
+    value_files = []
+)
+
+cnab_workflow(
+    name = "rosie-workflow",
+    description = "Deploy rosie",
+    tags = [
+        "env:dev",
+        "service:rosie",
+        "team:static-analysis",
+    ],
+    parallel = True,
+    tasks = [
+        ":rosie.delivery-platform.general1.us1.ddbuild.io",
+    ],
+    visibility = ["//visibility:public"],
+)
+

--- a/config/k8s/Chart.yaml
+++ b/config/k8s/Chart.yaml
@@ -1,0 +1,21 @@
+apiVersion: v2
+name: rosie
+description: A rosie server used internally to test our internal rule editor
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application.
+appVersion: 1.0

--- a/config/k8s/templates/_helpers.tpl
+++ b/config/k8s/templates/_helpers.tpl
@@ -1,0 +1,45 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "rosie.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "rosie.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "rosie.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "rosie.labels" -}}
+app.kubernetes.io/name: {{ include "rosie.name" . }}
+helm.sh/chart: {{ include "rosie.chart" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}

--- a/config/k8s/templates/deployment.yaml
+++ b/config/k8s/templates/deployment.yaml
@@ -1,0 +1,38 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "rosie.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+{{ include "rosie.labels" . | indent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "rosie.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "rosie.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+      annotations:
+    spec:
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ $.Values.global.docker.registry }}/{{ .Values.image.repository }}:{{ .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          resources:
+  {{ toYaml .Values.resources | indent 12 }}
+  {{- with .Values.nodeSelector }}
+nodeSelector:
+  {{ toYaml . | indent 8 }}
+  {{- end }}
+  {{- with .Values.affinity }}
+affinity:
+  {{ toYaml . | indent 8 }}
+  {{- end }}
+  {{- with .Values.tolerations }}
+tolerations:
+  {{ toYaml . | indent 8 }}
+  {{- end }}

--- a/config/k8s/templates/nodegroup.yaml
+++ b/config/k8s/templates/nodegroup.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.createNodeGroup }}
+apiVersion: datadoghq.com/v1
+kind: NodeGroup
+metadata:
+  name: {{ .Values.nodegroup.name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    team: release-engineering
+  finalizers:
+    - do-not-delete.datadoghq.com
+spec:
+  aws:
+    group:
+      minSize: {{ .Values.nodegroup.minSize }}
+    launchConfiguration:
+      instanceType: {{ .Values.nodegroup.aws.instanceType }}
+  gcp:
+    instanceTemplate:
+      properties:
+        machineType: {{ .Values.nodegroup.gcp.machineType }}
+  {{- end }}

--- a/config/k8s/values.yaml
+++ b/config/k8s/values.yaml
@@ -1,0 +1,21 @@
+image:
+  repository: "464622532012.dkr.ecr.us-east-1.amazonaws.com/rosie"
+  pullPolicy: IfNotPresent
+
+test:
+  image:
+    # Filled in by bazel
+    repository: "464622532012.dkr.ecr.us-east-1.amazonaws.com/rosie"
+    tag: null
+
+replicaCount: 1
+
+# if set to true, you need the provide the nodegroup values too
+createNodeGroup: false
+nodegroup:
+  name: delivery-platform
+  minSize: 1
+  aws:
+    instanceType: m5.large
+  gcp:
+    machineType: n1-standard-2


### PR DESCRIPTION
**What problem we are trying to solve?**

We want to deploy rosie in k8s in ddbuilt. 


**Solution**

We need to follow the steps to integrate with the [SDP UI](https://datadoghq.atlassian.net/wiki/spaces/sdpui/pages/1985774480/Getting+Started+with+the+SDP+UI). The objective is to create a CNAB workflow. We need to define and build it with bazel. Even if we build with gradle, we will use bazel to build the CNAB workflow.

**Open questions**

 - Did we define everything as it should
 - How to verify that everything is working (tried to run `bzl run //config/k8s:rosie.delivery-platform.general1.us1.ddbuild.io` but nothing worked)