### PR TITLE
[STAT-129] Generate valid uri-references for `ArtifactLocations`

### DIFF
--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -58,6 +58,7 @@ dependencies {
 
     testImplementation("net.jimblackler.jsonschemafriend:core:0.11.4")
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.9.2")
+    testImplementation("org.junit.jupiter:junit-jupiter-params:5.9.2")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.9.2")
 }
 

--- a/cli/src/main/java/io/codiga/cli/model/sarif/SarifArtifactLocation.java
+++ b/cli/src/main/java/io/codiga/cli/model/sarif/SarifArtifactLocation.java
@@ -4,7 +4,7 @@ import lombok.Builder;
 
 import java.nio.file.Path;
 
-import static io.codiga.cli.utils.SarifUtils.stripLeadingSlash;
+import static io.codiga.cli.utils.SarifUtils.uriReference;
 
 /**
  * Specifies the location of an artifact.
@@ -26,7 +26,7 @@ public class SarifArtifactLocation {
     public static SarifArtifactLocation generate(String s) {
         return SarifArtifactLocation
             .builder()
-            .uri(stripLeadingSlash(s))
+            .uri(uriReference(s).toString())
             .build();
     }
 }

--- a/cli/src/main/java/io/codiga/cli/model/sarif/SarifResultArtifactLocation.java
+++ b/cli/src/main/java/io/codiga/cli/model/sarif/SarifResultArtifactLocation.java
@@ -4,7 +4,7 @@ import lombok.Builder;
 
 import java.nio.file.Path;
 
-import static io.codiga.cli.utils.SarifUtils.stripLeadingSlash;
+import static io.codiga.cli.utils.SarifUtils.uriReference;
 
 /**
  * Specifies the location of an artifact.
@@ -26,7 +26,7 @@ public class SarifResultArtifactLocation {
     public static SarifResultArtifactLocation generate(String uri) {
         return SarifResultArtifactLocation
             .builder()
-            .uri(stripLeadingSlash(uri))
+            .uri(uriReference(uri).toString())
             .build();
     }
 }

--- a/cli/src/main/java/io/codiga/cli/utils/SarifUtils.java
+++ b/cli/src/main/java/io/codiga/cli/utils/SarifUtils.java
@@ -7,7 +7,9 @@ import io.codiga.cli.model.sarif.SarifReport;
 import io.codiga.model.error.RuleResult;
 import io.codiga.model.error.Severity;
 
+import java.net.URI;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.List;
 
 /**
@@ -74,5 +76,16 @@ public class SarifUtils {
             return s.substring(1);
         }
         return s;
+    }
+
+    /**
+     * Generate a valid URI relativized using the working directory from an uri in String format.
+     * Typically used to generate the URI-references for the locations in the SARIF reports.
+     * @param uriStr the uri in String format
+     * @return the URI relativized from the working directory
+     */
+    public static URI uriReference(String uriStr) {
+        var uri = Paths.get(stripLeadingSlash(uriStr)).toUri();
+        return Paths.get("").toUri().relativize(uri);
     }
 }

--- a/cli/src/test/java/io/codiga/cli/utils/SarifUtilsTest.java
+++ b/cli/src/test/java/io/codiga/cli/utils/SarifUtilsTest.java
@@ -17,6 +17,9 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.File;
 import java.io.IOException;
@@ -25,8 +28,10 @@ import java.util.Base64;
 import java.util.List;
 import java.util.Map;
 import java.util.logging.Logger;
+import java.util.stream.Stream;
 
 import static io.codiga.cli.utils.SarifUtils.generateReport;
+import static io.codiga.cli.utils.SarifUtils.uriReference;
 import static org.junit.jupiter.api.Assertions.*;
 
 public class SarifUtilsTest {
@@ -238,5 +243,20 @@ public class SarifUtilsTest {
                 List.of(new File("foo/bar").toPath()),
                 List.of(violation),
                 List.of())));
+    }
+
+    public static Stream<Arguments> generateURIs() {
+        return Stream.of(
+                Arguments.of("foo/bar", "foo/bar"),
+                Arguments.of("/foo/bar","foo/bar"),
+                Arguments.of("/foo xyz/bar", "foo%20xyz/bar")
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("generateURIs")
+    @DisplayName("URI-references generated are valid.")
+    public void testUriReferenceGeneration(String uri, String expectedUriReference) {
+        assertEquals(expectedUriReference, uriReference(uri).toString());
     }
 }


### PR DESCRIPTION
## What problem are you trying to solve?

The SARIF `ArtifactLocation` contains an URI that must be compliant with the `uri-reference` of JSON Schema RFC.

This means that if the customer has a file kept in a folder with whitespaces, the path to that file in the report must be correctly encoded. Otherwise, the report will not pass the JSON-schema validation.

E.g: `foo bar/my_file.py` -> `foo%20bar/my_file.py`

## What is your solution?

Use the `Paths.relativize` method to generate correct URIs using the working directory as base.

## Alternatives considered

## What the reviewer should know
- Added a new testing dependency to support `@ParameterizedTest`.

**Tested in staging**

**Report**
<img width="383" alt="image" src="https://github.com/DataDog/rosie/assets/29516565/9599b2f3-b323-40dd-a778-563ef63d5920">

**Ingested Event**
<img width="341" alt="image" src="https://github.com/DataDog/rosie/assets/29516565/ac76220f-ba65-4499-8ed9-ed9a351ade2c">

