### PR TITLE
Update the image tag to release internally

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -45,7 +45,7 @@ trigger_internal_operator_image:
     branch: master
     strategy: depend
   variables:
-    IMAGE_VERSION: latest
+    IMAGE_VERSION: current
     IMAGE_NAME: rosie
     RELEASE_TAG: ${CI_COMMIT_REF_SLUG}
     BUILD_TAG: ${CI_COMMIT_REF_SLUG}


### PR DESCRIPTION
## What problem are you trying to solve?

We want to deploy in ECS with an image tag other than `latest`.

## What is your solution?

Use the tag `current`

## Alternatives considered

Other names but `current` seems not to be banned.

## What the reviewer should know

Look at the review at https://github.com/DataDog/images/pull/3930
