### PR TITLE
[STAT-147] fix json cli output

### DIFF
--- a/cli/src/main/java/io/codiga/cli/FileUtils.java
+++ b/cli/src/main/java/io/codiga/cli/FileUtils.java
@@ -1,5 +1,8 @@
 package io.codiga.cli;
 
+import static io.codiga.cli.utils.SarifUtils.generateReport;
+import static io.codiga.utils.SnakeCaseMapperUtils.getSnakeCaseMapper;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.io.Files;
 import io.codiga.analyzer.rule.AnalyzerRule;
@@ -7,13 +10,10 @@ import io.codiga.cli.model.Result;
 import io.codiga.cli.model.ViolationWithFilename;
 import io.codiga.cli.utils.SarifUtils;
 import io.codiga.model.error.RuleResult;
-
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.stream.Collectors;
-
-import static io.codiga.cli.utils.SarifUtils.generateReport;
 
 public class FileUtils {
 
@@ -31,7 +31,7 @@ public class FileUtils {
 
 
     public static void writeViolationsToFile(Path path, Result result) throws IOException {
-        ObjectMapper objectMapper = new ObjectMapper();
+        ObjectMapper objectMapper = getSnakeCaseMapper();
         objectMapper.writeValue(path.toFile(), result);
     }
 

--- a/core/src/main/java/io/codiga/utils/SnakeCaseMapperUtils.java
+++ b/core/src/main/java/io/codiga/utils/SnakeCaseMapperUtils.java
@@ -1,0 +1,18 @@
+package io.codiga.utils;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+
+/**
+ * Used to
+ */
+public class SnakeCaseMapperUtils {
+    public static ObjectMapper getSnakeCaseMapper() {
+        return new ObjectMapper()
+            // converts Java variables to snake_case JSON; and vice-versa
+            .setPropertyNamingStrategy(new PropertyNamingStrategies.SnakeCaseStrategy())
+            // converts unknown values to a default enum value (i.e. UNKNOWN)
+            .enable(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE);
+    }
+}

--- a/server/src/main/java/io/codiga/server/configuration/ServerConfiguration.java
+++ b/server/src/main/java/io/codiga/server/configuration/ServerConfiguration.java
@@ -1,8 +1,8 @@
 package io.codiga.server.configuration;
 
-import com.fasterxml.jackson.databind.DeserializationFeature;
+import static io.codiga.utils.SnakeCaseMapperUtils.getSnakeCaseMapper;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import io.codiga.server.services.InjectorService;
 import io.codiga.server.services.InjectorServiceImpl;
 import org.slf4j.Logger;
@@ -26,10 +26,6 @@ public class ServerConfiguration {
     @Bean
     @Primary
     public ObjectMapper objectMapper() {
-        return new ObjectMapper()
-            // converts Java variables to snake_case JSON; and vice-versa
-            .setPropertyNamingStrategy(new PropertyNamingStrategies.SnakeCaseStrategy())
-            // converts unknown values to a default enum value (i.e. UNKNOWN)
-            .enable(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE);
+        return getSnakeCaseMapper();
     }
 }

--- a/server/src/test/java/io/codiga/server/configuration/ServerTestConfiguration.java
+++ b/server/src/test/java/io/codiga/server/configuration/ServerTestConfiguration.java
@@ -1,15 +1,11 @@
 package io.codiga.server.configuration;
 
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import io.codiga.server.services.InjectorService;
 import io.codiga.server.services.InjectorServiceTestImpl;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Primary;
 
 @TestConfiguration
 public class ServerTestConfiguration {
@@ -20,15 +16,5 @@ public class ServerTestConfiguration {
     public InjectorService injectorService() {
         logger.info("loading test configuration");
         return new InjectorServiceTestImpl();
-    }
-
-    @Bean
-    @Primary
-    public ObjectMapper objectMapper() {
-        return new ObjectMapper()
-            // converts Java variables to snake_case JSON; and vice-versa
-            .setPropertyNamingStrategy(new PropertyNamingStrategies.SnakeCaseStrategy())
-            // converts unknown values to a default enum value (i.e. UNKNOWN)
-            .enable(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE);
     }
 }


### PR DESCRIPTION
## What problem are you trying to solve?

If you run an analysis using the CLI, you would get a response that isn't snake_case per our new conventions. In the output below, you can see `editType` and `ruleResultsWithError` are both still camelCase'd. 

```json
{"violations":[{"start":{"line":121,"col":23},"end":{"line":121,"col":40},"message":"timeout not defined","severity":"CRITICAL","category":"SAFETY","filename":"snippets_imports.py","rule":"python-best-practices/requests-timeout","fixes":[{"description":"add timeout argument","edits":[{"start":{"line":121,"col":39},"end":null,"editType":"ADD","content":", timeout=5"}]}]},{"start":{"line":49,"col":16},"end":{"line":49,"col":70},"message":"timeout not defined","severity":"CRITICAL","category":"SAFETY","filename":"graphql/common.py","rule":"python-best-practices/requests-timeout","fixes":[{"description":"add timeout argument","edits":[{"start":{"line":49,"col":69},"end":null,"editType":"ADD","content":", timeout=5"}]}]},{"start":{"line":70,"col":16},"end":{"line":70,"col":70},"message":"timeout not defined","severity":"CRITICAL","category":"SAFETY","filename":"graphql/common.py","rule":"python-best-practices/requests-timeout","fixes":[{"description":"add timeout argument","edits":[{"start":{"line":70,"col":69},"end":null,"editType":"ADD","content":", timeout=5"}]}]}],"ruleResultsWithError":[]}
```

## What is your solution?

Take the ObjectMapper from the server and make it into a util that can be used by the CLI and server to avoid duplication. 

## Alternatives considered

None

## What the reviewer should know

Running the same analysis from before, but with these updates, outputted the following. You can see `edit_type` and `rule_results_with_error` both correctly outputted in snake_case

```json
{"violations":[{"start":{"line":121,"col":23},"end":{"line":121,"col":40},"message":"timeout not defined","severity":"CRITICAL","category":"SAFETY","filename":"snippets_imports.py","rule":"python-best-practices/requests-timeout","fixes":[{"description":"add timeout argument","edits":[{"start":{"line":121,"col":39},"end":null,"edit_type":"ADD","content":", timeout=5"}]}]},{"start":{"line":49,"col":16},"end":{"line":49,"col":70},"message":"timeout not defined","severity":"CRITICAL","category":"SAFETY","filename":"graphql/common.py","rule":"python-best-practices/requests-timeout","fixes":[{"description":"add timeout argument","edits":[{"start":{"line":49,"col":69},"end":null,"edit_type":"ADD","content":", timeout=5"}]}]},{"start":{"line":70,"col":16},"end":{"line":70,"col":70},"message":"timeout not defined","severity":"CRITICAL","category":"SAFETY","filename":"graphql/common.py","rule":"python-best-practices/requests-timeout","fixes":[{"description":"add timeout argument","edits":[{"start":{"line":70,"col":69},"end":null,"edit_type":"ADD","content":", timeout=5"}]}]}],"rule_results_with_error":[]}
```