### PR TITLE
fix echo in release script

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
           java-version: '17'
           distribution: 'corretto'
       - name: Set the version
-        run: echo "package io.codiga.utils;\npublic final class Version {\n    public static final String CURRENT_VERSION = \"$GITHUB_SHA\";\n}" > core/src/main/java/io/codiga/utils/Version.java
+        run: echo $'package io.codiga.utils;\npublic final class Version {\n    public static final String CURRENT_VERSION = \"$GITHUB_SHA\";\n}' > core/src/main/java/io/codiga/utils/Version.java
       - name: Build with Gradle
         run: ./gradlew cli:build
       - name: Upload to release


### PR DESCRIPTION
## What problem are you trying to solve?

Newline characters are literally interpreted

## What is your solution?

Wrap the echo 

## Alternatives considered

None

## What the reviewer should know

This was the failed release that prompted this change: https://github.com/DataDog/rosie/actions/runs/5091984081