### PR TITLE
remove newlines and fix outer quotes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
           java-version: '17'
           distribution: 'corretto'
       - name: Set the version
-        run: echo $'package io.codiga.utils;\npublic final class Version {\n    public static final String CURRENT_VERSION = \"$GITHUB_SHA\";\n}' > core/src/main/java/io/codiga/utils/Version.java
+        run: echo "package io.codiga.utils; public final class Version { public static final String CURRENT_VERSION = \"$GITHUB_SHA\"; }" > core/src/main/java/io/codiga/utils/Version.java
       - name: Build with Gradle
         run: ./gradlew cli:build
       - name: Upload to release


### PR DESCRIPTION
## What problem are you trying to solve?

This command will not input the `GITHUB_SHA` token.

## What is your solution?

- revert the change made in #50
- remove the newline characters to fix the issue from #50

## Alternatives considered

None

## What the reviewer should know

This is the conclusion to the original issue of the CLI release action failing:
- #49 
- #50 