### PR TITLE
Adding more languages for Tree-Sitter

### DIFF
--- a/core/src/main/java/io/codiga/analyzer/treesitterpm/TreeSitterPatternMatching.java
+++ b/core/src/main/java/io/codiga/analyzer/treesitterpm/TreeSitterPatternMatching.java
@@ -24,7 +24,6 @@ import io.codiga.model.ast.common.TreeSitterAstElement;
 import io.codiga.model.context.Context;
 import io.codiga.model.error.RuleResult;
 import io.codiga.model.tree_sitter.TsPatternMatch;
-import io.codiga.parser.treesitter.utils.TreeSitterParsingContext;
 import java.io.UnsupportedEncodingException;
 import java.util.*;
 import org.slf4j.Logger;
@@ -66,8 +65,7 @@ public class TreeSitterPatternMatching extends AnalyzerCommon {
                     QueryCursor queryCursor = query.execute(tree.getRootNode());
                     QueryMatch queryMatch = queryCursor.nextMatch();
                     List<TsPatternMatch> matches = new ArrayList<>();
-                    TreeSitterParsingContext treeSitterParsingContext = new TreeSitterParsingContext(analyzerContext.getCode(), tree.getRootNode());
-
+                    
                     /**
                      * For each match
                      *  - build an object that contains each match for each capture

--- a/core/src/main/java/io/codiga/analyzer/treesitterpm/TreeSitterPatternMatching.java
+++ b/core/src/main/java/io/codiga/analyzer/treesitterpm/TreeSitterPatternMatching.java
@@ -1,5 +1,9 @@
 package io.codiga.analyzer.treesitterpm;
 
+import static io.codiga.model.RuleErrorCode.ERROR_RULE_INVALID_QUERY;
+import static io.codiga.utils.TreeSitterUtils.getTreeFromNode;
+import static io.codiga.utils.TreeSitterUtils.languageToTreeSitterLanguage;
+
 import ai.serenade.treesitter.Node;
 import ai.serenade.treesitter.Parser;
 import ai.serenade.treesitter.Tree;
@@ -16,20 +20,15 @@ import io.codiga.analyzer.rule.AnalyzerRule;
 import io.codiga.errorreporting.ErrorReportingInterface;
 import io.codiga.metrics.MetricsInterface;
 import io.codiga.model.Language;
-import io.codiga.model.ast.common.AstElement;
+import io.codiga.model.ast.common.TreeSitterAstElement;
 import io.codiga.model.context.Context;
 import io.codiga.model.error.RuleResult;
-import io.codiga.model.tsquery.TsPatternMatch;
+import io.codiga.model.tree_sitter.TsPatternMatch;
 import io.codiga.parser.treesitter.utils.TreeSitterParsingContext;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.io.UnsupportedEncodingException;
 import java.util.*;
-
-import static io.codiga.model.RuleErrorCode.ERROR_RULE_INVALID_QUERY;
-import static io.codiga.utils.TreeSitterUtils.getAstElement;
-import static io.codiga.utils.TreeSitterUtils.languageToTreeSitterLanguage;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class TreeSitterPatternMatching extends AnalyzerCommon {
 
@@ -75,12 +74,12 @@ public class TreeSitterPatternMatching extends AnalyzerCommon {
                      *  - add the match to the list of matches
                      */
                     while (queryMatch != null) {
-                        Map<String, AstElement> match = new HashMap<>();
+                        Map<String, TreeSitterAstElement> match = new HashMap<>();
                         for (QueryMatchCapture queryMatchCapture : queryMatch.getCaptures()) {
                             int idx = queryMatchCapture.index;
                             String name = captures.get(idx).getName();
                             Node node = queryMatchCapture.node;
-                            Optional<AstElement> astElementOptional = getAstElement(node, rule.language(), treeSitterParsingContext);
+                            Optional<TreeSitterAstElement> astElementOptional = getTreeFromNode(node);
                             match.put(name, astElementOptional.orElse(null));
                         }
                         matches.add(new TsPatternMatch(match, ruleContext));

--- a/core/src/main/java/io/codiga/constants/Languages.java
+++ b/core/src/main/java/io/codiga/constants/Languages.java
@@ -1,17 +1,18 @@
 package io.codiga.constants;
 
-import io.codiga.model.Language;
+import static io.codiga.model.Language.*;
 
+import io.codiga.model.Language;
 import java.util.List;
 import java.util.Map;
 
-import static io.codiga.model.Language.*;
-
 public class Languages {
-    public final static List<Language> SUPPORTED_LANGUAGES = List.of(PYTHON, JAVASCRIPT, TYPESCRIPT);
+    public final static List<Language> SUPPORTED_LANGUAGES = List.of(PYTHON, JAVASCRIPT, TYPESCRIPT, GO, YAML);
     public final static Map<Language, List<String>> LANGUAGE_EXTENSIONS = Map.of(
         PYTHON, List.of("py", "py3"),
         JAVASCRIPT, List.of("js", "jsx"),
-        TYPESCRIPT, List.of("ts", "tsx")
+        TYPESCRIPT, List.of("ts", "tsx"),
+        GO, List.of("go"),
+        YAML, List.of("yaml", "yml")
     );
 }

--- a/core/src/main/java/io/codiga/model/Language.java
+++ b/core/src/main/java/io/codiga/model/Language.java
@@ -3,8 +3,10 @@ package io.codiga.model;
 import com.fasterxml.jackson.annotation.JsonEnumDefaultValue;
 
 public enum Language {
+    GO,
     PYTHON,
     JAVASCRIPT,
     TYPESCRIPT,
+    YAML,
     @JsonEnumDefaultValue UNKNOWN
 }

--- a/core/src/main/java/io/codiga/model/ast/common/TreeSitterAstElement.java
+++ b/core/src/main/java/io/codiga/model/ast/common/TreeSitterAstElement.java
@@ -3,10 +3,9 @@ package io.codiga.model.ast.common;
 import ai.serenade.treesitter.Node;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.codiga.model.common.Position;
+import java.util.List;
 import lombok.Builder;
 import lombok.extern.jackson.Jacksonized;
-
-import java.util.List;
 
 /**
  * Represents a TreeSitter AST element
@@ -25,8 +24,8 @@ public class TreeSitterAstElement {
         return TreeSitterAstElement
                 .builder()
                 .astType(node.getType())
-                .start(new Position(node.getStartPosition().row, node.getStartPosition().column))
-                .end(new Position(node.getEndPosition().row, node.getEndPosition().column))
+                .start(new Position(node.getStartPosition().row + 1, node.getStartPosition().column + 1))
+                .end(new Position(node.getEndPosition().row + 1, node.getEndPosition().column + 1))
                 .fieldName(fieldName)
                 .children(children)
                 .parent(parent)

--- a/core/src/main/java/io/codiga/model/tree_sitter/TsPatternMatch.java
+++ b/core/src/main/java/io/codiga/model/tree_sitter/TsPatternMatch.java
@@ -1,6 +1,7 @@
-package io.codiga.model.tsquery;
+package io.codiga.model.tree_sitter;
 
 import io.codiga.model.ast.common.AstElement;
+import io.codiga.model.ast.common.TreeSitterAstElement;
 import io.codiga.model.context.Context;
 import org.graalvm.polyglot.HostAccess;
 import org.graalvm.polyglot.proxy.ProxyHashMap;
@@ -16,7 +17,7 @@ public class TsPatternMatch {
     public ProxyHashMap captures;
 
 
-    public TsPatternMatch(Map<String, AstElement> matches, Context context) {
+    public TsPatternMatch(Map<String, TreeSitterAstElement> matches, Context context) {
         this.captures = ProxyHashMap.from(Collections.unmodifiableMap(matches));
         this.context = context;
     }

--- a/server/src/test/java/io/codiga/server/e2e/go/tsquery/FunctionNameTest.java
+++ b/server/src/test/java/io/codiga/server/e2e/go/tsquery/FunctionNameTest.java
@@ -1,0 +1,82 @@
+package io.codiga.server.e2e.go.tsquery;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.codiga.model.Language;
+import io.codiga.server.e2e.E2EBase;
+import io.codiga.server.response.Response;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class FunctionNameTest extends E2EBase {
+
+  private static final Logger logger = LoggerFactory.getLogger(FunctionNameTest.class);
+
+  String code = """
+package main
+
+import "fmt"
+
+func foobar(x int, y int) int {
+	return x + y
+}
+
+func main() {
+	fmt.Println(add(42, 13))
+}""";
+
+  String fixedCode = """
+package main
+
+import "fmt"
+
+func baz(x int, y int) int {
+	return x + y
+}
+
+func main() {
+	fmt.Println(add(42, 13))
+}""";
+
+  String tsQuery =
+      """
+(function_declaration
+  name: (identifier) @functionname
+  (#eq? @functionname "foobar")
+)
+            """;
+
+  String ruleCodeUpdate =
+      """
+
+            
+            function visit(node, filename, code) {
+
+                const functionName = node.captures["functionname"];
+                
+                if(functionName && getCode(functionName.start, functionName.end, code) === "foobar") {
+                    const error = buildError(functionName.start.line, functionName.start.col, functionName.end.line, functionName.end.col,
+                                             "invalid name", "CRITICAL", "security");
+
+                    const edit = buildEdit(functionName.start.line, functionName.start.col, functionName.end.line, functionName.end.col, "update", "baz");
+                    const fix = buildFix("use bar", [edit]);
+                    addError(error.addFix(fix));
+                }
+            }
+            """;
+
+  @Test
+  @DisplayName("Replace function name foobar by baz")
+  public void testBasicTreeSitterQuery() throws Exception {
+    Response response =
+        executeTestTsQuery(
+            "bla.js", code, Language.GO, ruleCodeUpdate, "ts-query-test", tsQuery, true);
+    logger.info(response.toString());
+
+    assertEquals(1, response.ruleResponses.size());
+    assertEquals(
+        fixedCode, applyFix(code, response.ruleResponses.get(0).violations.get(0).fixes.get(0)));
+  }
+}

--- a/server/src/test/java/io/codiga/server/e2e/javascript/tsquery/FunctionNameTest.java
+++ b/server/src/test/java/io/codiga/server/e2e/javascript/tsquery/FunctionNameTest.java
@@ -1,0 +1,87 @@
+package io.codiga.server.e2e.javascript.tsquery;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.codiga.model.Language;
+import io.codiga.server.e2e.E2EBase;
+import io.codiga.server.response.Response;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class FunctionNameTest extends E2EBase {
+
+  private static final Logger logger = LoggerFactory.getLogger(FunctionNameTest.class);
+
+  String code = """
+function foobar() {
+	console.log("efweF");
+}""";
+
+  String fixedCode = """
+function baz() {
+	console.log("efweF");
+}""";
+
+  String tsQuery =
+      """
+(function_declaration
+  name: (identifier) @functionname
+  (#eq? @functionname "foobar")
+)
+            """;
+
+  String ruleCodeUpdate =
+      """
+            function getCode(start, end, code) {
+              const lines = code.split("\\n");
+              const startLine = start.line - 1;
+              const startCol = start.col - 1;
+              const endLine = end.line - 1;
+              const endCol = end.col - 1;
+              
+              var startChar = 0;
+              for (var i = 0 ; i < startLine ; i++) {
+                startChar = startChar + len(lines[i]) + 1;
+              }
+              startChar = startChar + startCol;
+              
+              var endChar = 0;
+              for (var i = 0 ; i < startLine ; i++) {
+                endChar = endChar + len(lines[i]) + 1;
+              }
+              endChar = endChar + endCol;
+              
+              return code.substring(startChar, endChar);
+              
+            }
+            
+            function visit(node, filename, code) {
+
+                const functionName = node.captures["functionname"];
+                
+                if(functionName && getCode(functionName.start, functionName.end, code) === "foobar") {
+                    const error = buildError(functionName.start.line, functionName.start.col, functionName.end.line, functionName.end.col,
+                                             "invalid name", "CRITICAL", "security");
+
+                    const edit = buildEdit(functionName.start.line, functionName.start.col, functionName.end.line, functionName.end.col, "update", "baz");
+                    const fix = buildFix("use bar", [edit]);
+                    addError(error.addFix(fix));
+                }
+            }
+            """;
+
+  @Test
+  @DisplayName("Replace function name foobar by baz")
+  public void testBasicTreeSitterQuery() throws Exception {
+    Response response =
+        executeTestTsQuery(
+            "bla.js", code, Language.JAVASCRIPT, ruleCodeUpdate, "ts-query-test", tsQuery, true);
+    logger.info(response.toString());
+
+    assertEquals(1, response.ruleResponses.size());
+    assertEquals(
+        fixedCode, applyFix(code, response.ruleResponses.get(0).violations.get(0).fixes.get(0)));
+  }
+}

--- a/server/src/test/java/io/codiga/server/e2e/javascript/tsquery/FunctionNameTest.java
+++ b/server/src/test/java/io/codiga/server/e2e/javascript/tsquery/FunctionNameTest.java
@@ -33,30 +33,7 @@ function baz() {
             """;
 
   String ruleCodeUpdate =
-      """
-            function getCode(start, end, code) {
-              const lines = code.split("\\n");
-              const startLine = start.line - 1;
-              const startCol = start.col - 1;
-              const endLine = end.line - 1;
-              const endCol = end.col - 1;
-              
-              var startChar = 0;
-              for (var i = 0 ; i < startLine ; i++) {
-                startChar = startChar + len(lines[i]) + 1;
-              }
-              startChar = startChar + startCol;
-              
-              var endChar = 0;
-              for (var i = 0 ; i < startLine ; i++) {
-                endChar = endChar + len(lines[i]) + 1;
-              }
-              endChar = endChar + endCol;
-              
-              return code.substring(startChar, endChar);
-              
-            }
-            
+      """            
             function visit(node, filename, code) {
 
                 const functionName = node.captures["functionname"];

--- a/server/src/test/java/io/codiga/server/e2e/python/tsast/GetTsAstTest.java
+++ b/server/src/test/java/io/codiga/server/e2e/python/tsast/GetTsAstTest.java
@@ -1,5 +1,7 @@
 package io.codiga.server.e2e.python.tsast;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import io.codiga.model.Language;
 import io.codiga.server.e2e.E2EBase;
 import io.codiga.server.response.GetTreeSitterAstResponse;
@@ -7,10 +9,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import static io.codiga.server.response.ResponseErrors.ERROR_LANGUAGE_NOT_SUPPORTED;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
 
 public class GetTsAstTest extends E2EBase {
 
@@ -36,10 +34,10 @@ public class GetTsAstTest extends E2EBase {
 
         assertEquals(response.errors.size(), 0);
         assertEquals(response.result.astType, "module");
-        assertEquals(response.result.start.line, 0);
-        assertEquals(response.result.start.col, 0);
-        assertEquals(response.result.end.line, 0);
-        assertEquals(response.result.end.col, 0);
+        assertEquals(response.result.start.line, 1);
+        assertEquals(response.result.start.col, 1);
+        assertEquals(response.result.end.line, 1);
+        assertEquals(response.result.end.col, 1);
         assertEquals(response.result.children.size(), 0);
     }
 
@@ -54,10 +52,10 @@ public class GetTsAstTest extends E2EBase {
         assertEquals(response.result.children.get(0).astType, "expression_statement");
         assertEquals(response.result.children.get(0).children.size(), 1);
         assertEquals(response.result.children.get(0).children.get(0).astType, "assignment");
-        assertEquals(response.result.children.get(0).children.get(0).start.line, 0);
-        assertEquals(response.result.children.get(0).children.get(0).start.col, 0);
-        assertEquals(response.result.children.get(0).children.get(0).end.line, 0);
-        assertEquals(response.result.children.get(0).children.get(0).end.col, 20);
+        assertEquals(response.result.children.get(0).children.get(0).start.line, 1);
+        assertEquals(response.result.children.get(0).children.get(0).start.col, 1);
+        assertEquals(response.result.children.get(0).children.get(0).end.line, 1);
+        assertEquals(response.result.children.get(0).children.get(0).end.col, 21);
         assertEquals(response.result.children.get(0).children.get(0).children.size(), 2);
         assertEquals(response.result.children.get(0).children.get(0).children.get(0).astType, "identifier");
         assertEquals(response.result.children.get(0).children.get(0).children.get(0).fieldName, "left");
@@ -71,10 +69,10 @@ public class GetTsAstTest extends E2EBase {
         assertEquals(response.result.children.get(1).children.get(1).children.size(), 0);
         assertEquals(response.result.children.get(1).children.get(2).astType, "block");
         assertEquals(response.result.children.get(1).children.get(2).fieldName, "body");
-        assertEquals(response.result.children.get(1).children.get(2).start.line, 3);
-        assertEquals(response.result.children.get(1).children.get(2).start.col, 1);
-        assertEquals(response.result.children.get(1).children.get(2).end.line, 3);
-        assertEquals(response.result.children.get(1).children.get(2).end.col, 6);
+        assertEquals(response.result.children.get(1).children.get(2).start.line, 4);
+        assertEquals(response.result.children.get(1).children.get(2).start.col, 2);
+        assertEquals(response.result.children.get(1).children.get(2).end.line, 4);
+        assertEquals(response.result.children.get(1).children.get(2).end.col, 7);
         assertEquals(response.result.children.get(1).children.get(2).children.size(), 1);
         assertEquals(response.result.children.get(1).children.get(2).children.get(0).astType, "pass_statement");
         assertEquals(response.result.children.get(1).children.get(2).children.get(0).children.size(), 0);
@@ -89,20 +87,20 @@ public class GetTsAstTest extends E2EBase {
         assertEquals(response.result.astType, "module");
         assertEquals(response.result.children.size(), 2);
         assertEquals(response.result.children.get(0).astType, "ERROR");
-        assertEquals(response.result.children.get(0).start.line, 0);
-        assertEquals(response.result.children.get(0).start.col, 0);
-        assertEquals(response.result.children.get(0).end.line, 2);
-        assertEquals(response.result.children.get(0).end.col, 5);
+        assertEquals(response.result.children.get(0).start.line, 1);
+        assertEquals(response.result.children.get(0).start.col, 1);
+        assertEquals(response.result.children.get(0).end.line, 3);
+        assertEquals(response.result.children.get(0).end.col, 6);
         assertEquals(response.result.children.get(0).children.size(), 1);
         assertEquals(response.result.children.get(0).children.get(0).astType, "identifier");
         assertEquals(response.result.children.get(0).children.get(0).children.size(), 0);
         assertEquals(response.result.children.get(1).astType, "expression_statement");
         assertEquals(response.result.children.get(1).children.size(), 1);
         assertEquals(response.result.children.get(1).children.get(0).astType, "string");
-        assertEquals(response.result.children.get(1).children.get(0).start.line, 2);
-        assertEquals(response.result.children.get(1).children.get(0).start.col, 6);
-        assertEquals(response.result.children.get(1).children.get(0).end.line, 2);
-        assertEquals(response.result.children.get(1).children.get(0).end.col, 11);
+        assertEquals(response.result.children.get(1).children.get(0).start.line, 3);
+        assertEquals(response.result.children.get(1).children.get(0).start.col, 7);
+        assertEquals(response.result.children.get(1).children.get(0).end.line, 3);
+        assertEquals(response.result.children.get(1).children.get(0).end.col, 12);
         assertEquals(response.result.children.get(1).children.get(0).children.size(), 1);
         assertEquals(response.result.children.get(1).children.get(0).children.get(0).astType, "string_content");
     }

--- a/server/src/test/java/io/codiga/server/e2e/typescript/tsquery/FunctionNameTest.java
+++ b/server/src/test/java/io/codiga/server/e2e/typescript/tsquery/FunctionNameTest.java
@@ -1,0 +1,65 @@
+package io.codiga.server.e2e.typescript.tsquery;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.codiga.model.Language;
+import io.codiga.server.e2e.E2EBase;
+import io.codiga.server.response.Response;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class FunctionNameTest extends E2EBase {
+
+  private static final Logger logger = LoggerFactory.getLogger(FunctionNameTest.class);
+
+  String code = """
+function foobar() {
+	console.log("efweF");
+}""";
+
+  String fixedCode = """
+function baz() {
+	console.log("efweF");
+}""";
+
+  String tsQuery =
+      """
+(function_declaration
+  name: (identifier) @functionname
+  (#eq? @functionname "foobar")
+)
+            """;
+
+  String ruleCodeUpdate =
+      """
+            
+            function visit(node, filename, code) {
+
+                const functionName = node.captures["functionname"];
+                
+                if(functionName && getCode(functionName.start, functionName.end, code) === "foobar") {
+                    const error = buildError(functionName.start.line, functionName.start.col, functionName.end.line, functionName.end.col,
+                                             "invalid name", "CRITICAL", "security");
+
+                    const edit = buildEdit(functionName.start.line, functionName.start.col, functionName.end.line, functionName.end.col, "update", "baz");
+                    const fix = buildFix("use bar", [edit]);
+                    addError(error.addFix(fix));
+                }
+            }
+            """;
+
+  @Test
+  @DisplayName("Replace function name foobar by baz")
+  public void testBasicTreeSitterQuery() throws Exception {
+    Response response =
+        executeTestTsQuery(
+            "bla.js", code, Language.TYPESCRIPT, ruleCodeUpdate, "ts-query-test", tsQuery, true);
+    logger.info(response.toString());
+
+    assertEquals(1, response.ruleResponses.size());
+    assertEquals(
+        fixedCode, applyFix(code, response.ruleResponses.get(0).violations.get(0).fixes.get(0)));
+  }
+}

--- a/server/src/test/java/io/codiga/server/e2e/yaml/tsast/GetTsAstTest.java
+++ b/server/src/test/java/io/codiga/server/e2e/yaml/tsast/GetTsAstTest.java
@@ -1,0 +1,39 @@
+package io.codiga.server.e2e.yaml.tsast;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import io.codiga.model.Language;
+import io.codiga.server.e2e.E2EBase;
+import io.codiga.server.response.GetTreeSitterAstResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class GetTsAstTest extends E2EBase {
+
+    private static final Logger logger = LoggerFactory.getLogger(GetTsAstTest.class);
+
+
+    String validCode = """
+schema-version: v2
+service: super-service
+team: awesome-team
+contacts:
+    - type: slack
+      contact: https://org.slack.com/AWESOME_CHANNEL""";
+
+
+
+
+    @Test
+    @DisplayName("Test getting a TreeSitter AST for a valid file")
+    public void testFileAst() throws Exception {
+        GetTreeSitterAstResponse response = executeTreesitterAstTest(validCode, Language.YAML, "utf-8");
+        assertEquals(response.errors.size(), 0);
+        assertNotNull(response.result);
+        assertNotNull(response.result.astType);
+    }
+
+}

--- a/server/src/test/java/io/codiga/server/e2e/yaml/tsquery/ApiVersionTest.java
+++ b/server/src/test/java/io/codiga/server/e2e/yaml/tsquery/ApiVersionTest.java
@@ -1,0 +1,76 @@
+package io.codiga.server.e2e.yaml.tsquery;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.codiga.model.Language;
+import io.codiga.server.e2e.E2EBase;
+import io.codiga.server.response.Response;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ApiVersionTest extends E2EBase {
+
+  private static final Logger logger = LoggerFactory.getLogger(ApiVersionTest.class);
+
+  String code = """
+schema-version: v3
+service: super-service
+team: awesome-team
+contacts:
+    - type: slack
+      contact: https://org.slack.com/AWESOME_CHANNEL""";
+
+  String fixedCode = """
+schema-version: v2
+service: super-service
+team: awesome-team
+contacts:
+    - type: slack
+      contact: https://org.slack.com/AWESOME_CHANNEL""";
+
+  String tsQuery =
+      """
+(block_mapping_pair
+  (flow_node) @name
+  (flow_node) @value
+  (#eq? @name "schema-version")
+)
+            """;
+
+  String ruleCodeUpdate =
+      """
+            
+            function visit(node, filename, code) {
+
+                const n = node.captures["name"];
+                const v = node.captures["value"];
+                console.log(n);
+                console.log(v);
+                console.log(getCode(v.start, v.end, code));
+                
+                if(n && v && getCode(v.start, v.end, code) === "v3") {
+                    const error = buildError(v.start.line, v.start.col, v.end.line, v.end.col,
+                                             "invalid version", "CRITICAL", "BEST_PRACTICE");
+
+                    const edit = buildEdit(v.start.line, v.start.col, v.end.line, v.end.col, "update", "v2");
+                    const fix = buildFix("use v2", [edit]);
+                    addError(error.addFix(fix));
+                }
+            }
+            """;
+
+  @Test
+  @DisplayName("Replace function name foobar by baz")
+  public void testBasicTreeSitterQuery() throws Exception {
+    Response response =
+        executeTestTsQuery(
+            "bla.js", code, Language.YAML, ruleCodeUpdate, "ts-query-test", tsQuery, true);
+    logger.info(response.toString());
+
+    assertEquals(1, response.ruleResponses.size());
+    assertEquals(
+        fixedCode, applyFix(code, response.ruleResponses.get(0).violations.get(0).fixes.get(0)));
+  }
+}


### PR DESCRIPTION
## What problem are you trying to solve?

We are migrating away from ANTLR and rather use Tree-Sitter and Tree-Sitter queries. This PR adds support for the following languages: JavaScript, TypeScript, Go and YAML.

## What is your solution?

Our solution is to add the languages in the server, make sure tree-sitter queries can be performed with the languages mentioned above.

## What the reviewer should know

1. We are changing the way we are processing the tree-sitter query. Instead of trying to build an AST element from Rosie, we are just passing the JSON representation of the tree-sitter node to the JavaScript code.
2. This representation does not contain the content of the code itself. We are adding a helper function to get the code from the `start` and `end` position. See `getCode` in `VmContext` [here](https://github.com/DataDog/rosie/pull/54/files#diff-9b20230044db3d18959be72114fc8a003a11d6baa45d0d326852727af3367cb1R46)
3. In rosie, the `start` and `end` position always starts at `1`. This is what the IDE are doing. We are updating the code to reflect this.