### PR TITLE
remove string decoding

### DIFF
--- a/cli/src/main/java/io/codiga/cli/model/sarif/SarifMultiformatMessage.java
+++ b/cli/src/main/java/io/codiga/cli/model/sarif/SarifMultiformatMessage.java
@@ -2,8 +2,6 @@ package io.codiga.cli.model.sarif;
 
 import lombok.Builder;
 
-import java.util.Base64;
-
 /**
  * Encapsulates a multiformat message intended to be read by the end user.
  * <br>
@@ -18,6 +16,6 @@ public class SarifMultiformatMessage {
             return null;
         }
 
-        return SarifMultiformatMessage.builder().text(new String(Base64.getDecoder().decode(str.getBytes()))).build();
+        return SarifMultiformatMessage.builder().text(str).build();
     }
 }

--- a/cli/src/test/java/io/codiga/cli/utils/SarifUtilsTest.java
+++ b/cli/src/test/java/io/codiga/cli/utils/SarifUtilsTest.java
@@ -1,5 +1,9 @@
 package io.codiga.cli.utils;
 
+import static io.codiga.cli.utils.SarifUtils.generateReport;
+import static io.codiga.cli.utils.SarifUtils.uriReference;
+import static org.junit.jupiter.api.Assertions.*;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.codiga.analyzer.rule.AnalyzerRule;
 import io.codiga.cli.model.ViolationWithFilename;
@@ -9,6 +13,13 @@ import io.codiga.model.Language;
 import io.codiga.model.RuleType;
 import io.codiga.model.common.Position;
 import io.codiga.model.error.*;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Logger;
+import java.util.stream.Stream;
 import net.jimblackler.jsonschemafriend.Schema;
 import net.jimblackler.jsonschemafriend.SchemaException;
 import net.jimblackler.jsonschemafriend.SchemaStore;
@@ -21,23 +32,9 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import java.io.File;
-import java.io.IOException;
-import java.nio.file.Files;
-import java.util.Base64;
-import java.util.List;
-import java.util.Map;
-import java.util.logging.Logger;
-import java.util.stream.Stream;
-
-import static io.codiga.cli.utils.SarifUtils.generateReport;
-import static io.codiga.cli.utils.SarifUtils.uriReference;
-import static org.junit.jupiter.api.Assertions.*;
-
 public class SarifUtilsTest {
 
     private static final String SARIF_SCHEMA_PATH = "src/test/resources/sarif-standard/sarif-schema-2.1.0.json";
-    private static final String ENCODED_DESCRIPTION = new String(Base64.getEncoder().encode("myruledescription".getBytes()));
     private final Logger log = Logger.getLogger("Test");
 
     @BeforeAll
@@ -90,7 +87,7 @@ public class SarifUtilsTest {
 
         assertTrue(checkCompliance(
             generateReport(
-                List.of(new AnalyzerRule("myrule", ENCODED_DESCRIPTION, Language.PYTHON, RuleType.AST_CHECK, EntityChecked.ASSIGNMENT, "code", null, null, Map.of())),
+                List.of(new AnalyzerRule("myrule", "myruledescription", Language.PYTHON, RuleType.AST_CHECK, EntityChecked.ASSIGNMENT, "code", null, null, Map.of())),
                 List.of(new File("foo/bar").toPath()),
                 List.of(violation),
                 List.of())));
@@ -115,7 +112,7 @@ public class SarifUtilsTest {
 
         assertTrue(checkCompliance(
             generateReport(
-                List.of(new AnalyzerRule("myrule", ENCODED_DESCRIPTION, Language.PYTHON, RuleType.AST_CHECK, EntityChecked.ASSIGNMENT, "code", null, null, Map.of())),
+                List.of(new AnalyzerRule("myrule", "myruledescription", Language.PYTHON, RuleType.AST_CHECK, EntityChecked.ASSIGNMENT, "code", null, null, Map.of())),
                 List.of(new File("foo/bar").toPath()),
                 List.of(violation),
                 List.of())));
@@ -140,7 +137,7 @@ public class SarifUtilsTest {
 
         assertTrue(checkCompliance(
             generateReport(
-                List.of(new AnalyzerRule("myrule",ENCODED_DESCRIPTION, Language.PYTHON, RuleType.AST_CHECK, EntityChecked.ASSIGNMENT, "code", null, null, Map.of())),
+                List.of(new AnalyzerRule("myrule","myruledescription", Language.PYTHON, RuleType.AST_CHECK, EntityChecked.ASSIGNMENT, "code", null, null, Map.of())),
                 List.of(new File("foo/bar").toPath()),
                 List.of(violation),
                 List.of())));
@@ -179,8 +176,8 @@ public class SarifUtilsTest {
 
         SarifReport sarifReport = generateReport(
             List.of(
-                new AnalyzerRule("myrule1",ENCODED_DESCRIPTION, Language.PYTHON, RuleType.AST_CHECK, EntityChecked.ASSIGNMENT, "code", null, null, Map.of()),
-                new AnalyzerRule("myrule2",ENCODED_DESCRIPTION, Language.PYTHON, RuleType.AST_CHECK, EntityChecked.ASSIGNMENT, "code", null, null, Map.of())),
+                new AnalyzerRule("myrule1","myruledescription", Language.PYTHON, RuleType.AST_CHECK, EntityChecked.ASSIGNMENT, "code", null, null, Map.of()),
+                new AnalyzerRule("myrule2","myruledescription", Language.PYTHON, RuleType.AST_CHECK, EntityChecked.ASSIGNMENT, "code", null, null, Map.of())),
             List.of(new File("foo/bar").toPath()),
             List.of(violation1, violation2),
             List.of());
@@ -218,7 +215,7 @@ public class SarifUtilsTest {
 
         assertTrue(checkCompliance(
             generateReport(
-                List.of(new AnalyzerRule("myrule",ENCODED_DESCRIPTION, Language.PYTHON, RuleType.AST_CHECK, EntityChecked.ASSIGNMENT, "code", null, null, Map.of())),
+                List.of(new AnalyzerRule("myrule","myruledescription", Language.PYTHON, RuleType.AST_CHECK, EntityChecked.ASSIGNMENT, "code", null, null, Map.of())),
                 List.of(new File("foo/bar").toPath()),
                 List.of(violation),
                 List.of())));
@@ -239,7 +236,7 @@ public class SarifUtilsTest {
 
         assertFalse(checkCompliance(
             generateReport(
-                List.of(new AnalyzerRule("myrule", ENCODED_DESCRIPTION, Language.PYTHON, RuleType.AST_CHECK, EntityChecked.ASSIGNMENT, "code", null, null, Map.of())),
+                List.of(new AnalyzerRule("myrule", "myruledescription", Language.PYTHON, RuleType.AST_CHECK, EntityChecked.ASSIGNMENT, "code", null, null, Map.of())),
                 List.of(new File("foo/bar").toPath()),
                 List.of(violation),
                 List.of())));


### PR DESCRIPTION
## What problem are you trying to solve?

[In a previous commit](https://github.com/DataDog/rosie/commit/463ab70bd99323c4c555d2695716cb0653fa7f84#diff-5ae2c74ad5ce6ad640e724e017dfab06aef27104fb9b3ac792ba0b2dd648a0f1R58), the description field was changed to send a decoded string instead of an encoded one. When running the CLI while pulling the rules from the API, the analysis will fail as seen in the image below

<img width="761" alt="Screenshot 2023-05-30 at 2 30 54 PM" src="https://github.com/DataDog/rosie/assets/33348592/ae083529-4538-49ce-9651-48e0478fd01f">

## What is your solution?

We don't need to decode the description in `SarifMultiformatMessage` anymore, so I removed that decoding.

## Alternatives considered

Revert the previous change of decoding the description, but IMO having the `AnalyzerRule` class accept decoded values for all fields is more consistent and easier to reason about, then having one not follow that mold. 

## What the reviewer should know

I ran this change with recently migrated rules from the prod API to confirm the output is correct