### PR TITLE
attempt to fix memleak

### DIFF
--- a/core/src/main/java/io/codiga/analyzer/ast/vm/VmContext.java
+++ b/core/src/main/java/io/codiga/analyzer/ast/vm/VmContext.java
@@ -6,7 +6,11 @@ import io.codiga.analyzer.ast.common.ErrorReporting;
 import io.codiga.analyzer.rule.AnalyzerRule;
 import io.codiga.model.Language;
 import io.codiga.model.error.Violation;
-import java.io.*;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.PipedInputStream;
+import java.io.PipedOutputStream;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
@@ -32,7 +36,7 @@ public class VmContext {
         .denyAccess(Proxy.class)
         .denyAccess(Object.class, false)
         .build();
-    private static final int MAX_STATEMENTS = 1000000;
+    private static final int MAX_STATEMENTS = 2000000000;
     private final ErrorReporting errorReporting;
 
   private final String[] helperFunctions =

--- a/core/src/main/java/io/codiga/analyzer/ast/vm/VmContext.java
+++ b/core/src/main/java/io/codiga/analyzer/ast/vm/VmContext.java
@@ -36,7 +36,7 @@ public class VmContext {
         .denyAccess(Proxy.class)
         .denyAccess(Object.class, false)
         .build();
-    private static final int MAX_STATEMENTS = 1000000;
+    private static final int MAX_STATEMENTS = 10000000;
     private final ErrorReporting errorReporting;
 
   private final String[] helperFunctions =

--- a/core/src/main/java/io/codiga/analyzer/ast/vm/VmContext.java
+++ b/core/src/main/java/io/codiga/analyzer/ast/vm/VmContext.java
@@ -36,7 +36,7 @@ public class VmContext {
         .denyAccess(Proxy.class)
         .denyAccess(Object.class, false)
         .build();
-    private static final int MAX_STATEMENTS = 2000000000;
+    private static final int MAX_STATEMENTS = 1000000;
     private final ErrorReporting errorReporting;
 
   private final String[] helperFunctions =

--- a/core/src/main/java/io/codiga/utils/TreeSitterUtils.java
+++ b/core/src/main/java/io/codiga/utils/TreeSitterUtils.java
@@ -73,12 +73,11 @@ public class TreeSitterUtils {
   }
 
   public static Optional<TreeSitterAstElement> getTreeFromNode(Node node) {
+    var visitedChildren = false;
+    var isFinished = false;
+    TreeSitterAstElement current = null;
+    TreeSitterAstElement parent = null;
     try (TreeCursor treeCursor = node.walk()) {
-      var visitedChildren = false;
-      var isFinished = false;
-      TreeSitterAstElement current = null;
-      TreeSitterAstElement parent = null;
-
       while (!isFinished) {
 
         if (visitedChildren) {
@@ -111,8 +110,7 @@ public class TreeSitterUtils {
           }
         }
       }
-      treeCursor.close();
-      return Optional.ofNullable(parent);
     }
+    return Optional.ofNullable(parent);
   }
 }

--- a/core/src/main/java/io/codiga/utils/TreeSitterUtils.java
+++ b/core/src/main/java/io/codiga/utils/TreeSitterUtils.java
@@ -1,6 +1,10 @@
 package io.codiga.utils;
 
-import ai.serenade.treesitter.*;
+import ai.serenade.treesitter.Languages;
+import ai.serenade.treesitter.Node;
+import ai.serenade.treesitter.Parser;
+import ai.serenade.treesitter.Tree;
+import ai.serenade.treesitter.TreeCursor;
 import io.codiga.model.Language;
 import io.codiga.model.ast.common.AstElement;
 import io.codiga.model.ast.common.TreeSitterAstElement;
@@ -53,65 +57,62 @@ public class TreeSitterUtils {
 
   public static Optional<TreeSitterAstElement> getFullAstTree(String code, Language language) {
     Optional<Long> treeSitterLanguage = languageToTreeSitterLanguage(language);
-    TreeCursor treeCursor;
     if (treeSitterLanguage.isEmpty()) {
       return Optional.empty();
     }
 
-    try(Parser parser = new Parser()) {
+    try (Parser parser = new Parser()) {
       parser.setLanguage(treeSitterLanguage.get());
-      Tree tree = parser.parseString(code);
-      return getTreeFromNode(tree.getRootNode());
+      try (Tree tree = parser.parseString(code)) {
+        return getTreeFromNode(tree.getRootNode());
+      }
     } catch (UnsupportedEncodingException e) {
       logger.info("error when decoding the code");
       return Optional.empty();
     }
   }
 
-    public static Optional<TreeSitterAstElement> getTreeFromNode(Node node) {
-        TreeCursor treeCursor = node.walk();
-        var visitedChildren = false;
-        var isFinished = false;
-        TreeSitterAstElement current = null;
-        TreeSitterAstElement parent = null;
+  public static Optional<TreeSitterAstElement> getTreeFromNode(Node node) {
+    try (TreeCursor treeCursor = node.walk()) {
+      var visitedChildren = false;
+      var isFinished = false;
+      TreeSitterAstElement current = null;
+      TreeSitterAstElement parent = null;
 
-        while (!isFinished) {
+      while (!isFinished) {
 
-            if (visitedChildren) {
-                if (treeCursor.gotoNextSibling()) {
-                    visitedChildren = false;
-                } else if (treeCursor.gotoParent() && parent != null && parent.parent != null) {
-                    parent = parent.parent;
-                    visitedChildren = true;
-                } else {
-                    if (parent == null && current != null) {
-                        parent = current;
-                    }
-                    isFinished = true;
-                    treeCursor.close();
-                }
-            } else {
-                if (treeCursor.getCurrentNode().isNamed()) {
-                    current =
-                        TreeSitterAstElement.create(
-                            treeCursor.getCurrentNode(),
-                            treeCursor.getCurrentFieldName(),
-                            new ArrayList<>(),
-                            parent);
-                    if (parent != null) {
-                        parent.children.add(current);
-                    }
-                }
-
-                if (treeCursor.gotoFirstChild()) {
-                    parent = current;
-                    visitedChildren = false;
-                } else {
-                    visitedChildren = true;
-                }
+        if (visitedChildren) {
+          if (treeCursor.gotoNextSibling()) {
+            visitedChildren = false;
+          } else if (treeCursor.gotoParent() && parent != null && parent.parent != null) {
+            parent = parent.parent;
+          } else {
+            if (parent == null && current != null) {
+              parent = current;
             }
+            isFinished = true;
+          }
+        } else {
+          if (treeCursor.getCurrentNode().isNamed()) {
+            current =
+                TreeSitterAstElement.create(
+                    treeCursor.getCurrentNode(),
+                    treeCursor.getCurrentFieldName(),
+                    new ArrayList<>(),
+                    parent);
+            if (parent != null) {
+              parent.children.add(current);
+            }
+          }
+          if (treeCursor.gotoFirstChild()) {
+            parent = current;
+          } else {
+            visitedChildren = true;
+          }
         }
-
-        return Optional.ofNullable(parent);
+      }
+      treeCursor.close();
+      return Optional.ofNullable(parent);
     }
+  }
 }


### PR DESCRIPTION
## What problem are you trying to solve?

We detected a memory leak and the analyzer is quickly running out of memory.

## What is your solution?

Correctly use all tree-sitter JNI in `try()` block, which forces freeing the memory allocated for all resources.

We looked at the JNI wrapper between tree-sitter and Java. The wrapper call the C code from tree-sitter and provides an interface with Java. For each object, we allocate the resource, store the pointer in the Java object and delete when the resource is closed via the close method.

In the wrapper, we use a class called [`ResourceWithPointer`](https://github.com/juli1/java-tree-sitter/blob/master/src/main/java/ai/serenade/treesitter/query/internals/ResourceWithPointer.java) that handle the logic to free the memory once we close the resource. To make sure the memory is free when we close the object, the class implements [`AutoCloseable`](https://docs.oracle.com/javase/8/docs/api/java/lang/AutoCloseable.html). However, to ensure that the `close()` call is used, we need to either:
 - explicitly call `.close()` on the object
 - use the object via a try with resources statement (`try(...) {}` pattern - see [more here](https://docs.oracle.com/javase/tutorial/essential/exceptions/tryResourceClose.html))

In some parts of the code, we allocate tree sitter object but never free the memory. We never called the `.close()` method and we never used a try with resources statement. The memory is therefore not freed, which potentially leads to memory leak.

The fix consists in adding the appropriate call to the try-with-statement to ensure the resource is closed. See in particular:
 - `TreeSitterPatternMatching.java` and the `QueryCursor`
 - `CodigaVisitor.java` and the call to `parser.parseString(code).getRootNode();` that hides an allocation of a Tree
 - `TreeSitterUtils.java` and the instantiation of a Tree directly `Tree tree = parser.parseString(code);`


## Important

I was able to check we have **less** memory allocation. I tried to control the max heap of the JVM but execution still gets more memory than specific (option `-Xmx` of the JVM). This fix may be enough but we may need further fixes later.


## Note to the reviewer

Each time we use a tree-sitter object, we **MUST** use a try-with-statement. This image may be useful for further reviews.

![image](https://github.com/DataDog/rosie/assets/993972/cbe842b4-26cc-41fd-a2e5-a49cee540abc)
