### PR TITLE
add support for multiple nodes for a match with the same capture

### DIFF
--- a/core/src/main/java/io/codiga/analyzer/ast/vm/VmContext.java
+++ b/core/src/main/java/io/codiga/analyzer/ast/vm/VmContext.java
@@ -46,28 +46,33 @@ public class VmContext {
             + "    console.log(`${property}: ${JSON.stringify(object[property])}`);\n"
             + "  }\n"
             + "}\n",
-          """
+        """
             function getCode(start, end, code) {
               const lines = code.split("\\n");
               const startLine = start.line - 1;
               const startCol = start.col - 1;
               const endLine = end.line - 1;
               const endCol = end.col - 1;
-              
+
               var startChar = 0;
               for (var i = 0 ; i < startLine ; i++) {
                 startChar = startChar + lines[i].length + 1;
               }
               startChar = startChar + startCol;
-              
+
               var endChar = 0;
               for (var i = 0 ; i < startLine ; i++) {
                 endChar = endChar + lines[i].length + 1;
               }
               endChar = endChar + endCol;
-              
+
               return code.substring(startChar, endChar);
-            };"""
+            };""",
+        """
+        function getCodeForNode(node, code){
+            return getCode(node.start, node.end, code);
+        }
+        """
       };
 
     private final String[] PYTHON_HELPER_FUNCTIONS = new String[]{

--- a/core/src/main/java/io/codiga/analyzer/treesitterpm/TreeSitterPatternMatching.java
+++ b/core/src/main/java/io/codiga/analyzer/treesitterpm/TreeSitterPatternMatching.java
@@ -79,14 +79,22 @@ public class TreeSitterPatternMatching extends AnalyzerCommon {
                          */
                         while (queryMatch != null) {
                             Map<String, TreeSitterAstElement> match = new HashMap<>();
+                            Map<String, List<TreeSitterAstElement>> matchesList = new HashMap<>();
                             for (QueryMatchCapture queryMatchCapture : queryMatch.getCaptures()) {
                                 int idx = queryMatchCapture.index;
                                 String name = captures.get(idx).getName();
                                 Node node = queryMatchCapture.node;
                                 Optional<TreeSitterAstElement> astElementOptional = getTreeFromNode(node);
-                                match.put(name, astElementOptional.orElse(null));
+                                if (astElementOptional.isPresent()) {
+                                    match.put(name, astElementOptional.get());
+                                    if(!matchesList.containsKey(name)) {
+                                        matchesList.put(name, new ArrayList<>());
+                                    }
+                                    matchesList.get(name).add(astElementOptional.get());
+                                }
+
                             }
-                            matches.add(new TsPatternMatch(match, ruleContext));
+                            matches.add(new TsPatternMatch(match, matchesList, ruleContext));
                             queryMatch = queryCursor.nextMatch();
                         }
 

--- a/core/src/main/java/io/codiga/model/tree_sitter/TsPatternMatch.java
+++ b/core/src/main/java/io/codiga/model/tree_sitter/TsPatternMatch.java
@@ -1,24 +1,27 @@
 package io.codiga.model.tree_sitter;
 
-import io.codiga.model.ast.common.AstElement;
 import io.codiga.model.ast.common.TreeSitterAstElement;
 import io.codiga.model.context.Context;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 import org.graalvm.polyglot.HostAccess;
 import org.graalvm.polyglot.proxy.ProxyHashMap;
-
-import java.util.Collections;
-import java.util.Map;
 
 public class TsPatternMatch {
 
     @HostAccess.Export
     public Context context;
+
     @HostAccess.Export
     public ProxyHashMap captures;
 
+    @HostAccess.Export
+    public ProxyHashMap capturesList;
 
-    public TsPatternMatch(Map<String, TreeSitterAstElement> matches, Context context) {
+    public TsPatternMatch(Map<String, TreeSitterAstElement> matches, Map<String, List<TreeSitterAstElement>> matchesList, Context context) {
         this.captures = ProxyHashMap.from(Collections.unmodifiableMap(matches));
+        this.capturesList = ProxyHashMap.from(Collections.unmodifiableMap(matchesList));
         this.context = context;
     }
 

--- a/core/src/main/java/io/codiga/utils/TreeSitterUtils.java
+++ b/core/src/main/java/io/codiga/utils/TreeSitterUtils.java
@@ -81,7 +81,7 @@ public class TreeSitterUtils {
       while (!isFinished) {
 
         if (visitedChildren) {
-          if (treeCursor.gotoNextSibling()) {
+          if (treeCursor.gotoNextSibling()) { 
             visitedChildren = false;
           } else if (treeCursor.gotoParent() && parent != null && parent.parent != null) {
             parent = parent.parent;

--- a/server/src/test/java/io/codiga/server/e2e/python/tsquery/TsQueryListTest.java
+++ b/server/src/test/java/io/codiga/server/e2e/python/tsquery/TsQueryListTest.java
@@ -1,0 +1,80 @@
+package io.codiga.server.e2e.python.tsquery;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.codiga.model.Language;
+import io.codiga.server.e2e.E2EBase;
+import io.codiga.server.response.Response;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class TsQueryListTest extends E2EBase {
+
+    private static final Logger logger = LoggerFactory.getLogger(TsQueryListTest.class);
+
+    String code = """
+            class Foo:
+                def foo(arg1):
+                    pass
+                def foo2(arg2):
+                    pass""";
+
+
+    String fixedCode = """
+            def bar(arg1):
+                pass""";
+
+
+    String tsQuery = """
+                (class_definition
+                    body: (block
+                        (function_definition
+                            name: (identifier) @name
+                          parameters: (parameters) @params
+                        )+ @funcs
+                    )
+                )@class
+            """;
+
+    String ruleCodeUpdate = """
+            function visit(node, filename, code) {
+                    
+                const functions = node.capturesList["funcs"];
+                console.log(functions.length);
+                
+                functions.forEach(f => {
+                    if(f) {
+                        const functionName = f.children.filter(c => c.fieldName === "name")[0];
+                        const name = getCodeForNode(functionName, code);
+                        
+                        const error = buildError(functionName.start.line, functionName.start.col, functionName.end.line, functionName.end.col, 
+                                                 "invalid name", "CRITICAL", "security");
+    
+                        addError(error);
+                    }       
+                });
+                         
+            }
+            """;
+
+
+    @Test
+    @DisplayName("Test basic tree-sitter query")
+    public void testBasicTreeSitterQuery() throws Exception {
+        Response response = executeTestTsQuery(
+                "bla.py",
+                code,
+                Language.PYTHON,
+                ruleCodeUpdate,
+                "ts-query-test",
+                tsQuery,
+                true);
+        logger.info(response.toString());
+
+        assertEquals(1, response.ruleResponses.size());
+        assertEquals(2, response.ruleResponses.get(0).violations.size());
+    }
+
+}

--- a/server/src/test/java/io/codiga/server/e2e/python/tsquery/TsQueryPresenceTest.java
+++ b/server/src/test/java/io/codiga/server/e2e/python/tsquery/TsQueryPresenceTest.java
@@ -1,0 +1,87 @@
+package io.codiga.server.e2e.python.tsquery;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.codiga.model.Language;
+import io.codiga.server.e2e.E2EBase;
+import io.codiga.server.response.Response;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class TsQueryPresenceTest extends E2EBase {
+
+    private static final Logger logger = LoggerFactory.getLogger(TsQueryPresenceTest.class);
+
+    String code1 = """
+            def foo(arg1):
+                pass""";
+
+    String code2 = """
+            def foo():
+                pass""";
+
+
+    String tsQuery = """
+(function_definition
+  parameters: (parameters
+     (identifier)? @id
+  )
+)
+            """;
+
+    String ruleCodeUpdate = """
+            function visit(node, filename, code) {
+                    
+                if(node.captures.has("id")) {
+                    console.log("has the key");
+                    const c = node.captures["id"];
+                    const error = buildError(c.start.line, c.start.col, c.end.line, c.end.col, 
+                                             "invalid name", "CRITICAL", "security");
+                    addError(error);
+                } else {
+                   console.log("does not have the key");
+                }
+            }
+            """;
+
+
+    @Test
+    @DisplayName("Test to make sure that the node is present")
+    public void testPresent() throws Exception {
+        Response response = executeTestTsQuery(
+                "bla.py",
+                code1,
+                Language.PYTHON,
+                ruleCodeUpdate,
+                "ts-query-test",
+                tsQuery,
+                true);
+        logger.info(response.toString());
+
+        assertEquals(1, response.ruleResponses.size());
+        assertEquals(1, response.ruleResponses.get(0).violations.size());
+        assertTrue(response.ruleResponses.get(0).output.contains("has the key"));
+    }
+
+
+    @Test
+    @DisplayName("Test to check that the node is absent")
+    public void testAbsent() throws Exception {
+        Response response = executeTestTsQuery(
+            "bla.py",
+            code2,
+            Language.PYTHON,
+            ruleCodeUpdate,
+            "ts-query-test",
+            tsQuery,
+            true);
+        logger.info(response.toString());
+
+        assertEquals(1, response.ruleResponses.size());
+        assertEquals(0, response.ruleResponses.get(0).violations.size());
+        assertTrue(response.ruleResponses.get(0).output.contains("does not have the key"));
+    }
+}


### PR DESCRIPTION
## What problem are you trying to solve?

Today, we assign the capture to a hasmap that associate the node with the name in the capture.

It works well for query such as 

```
(function_definition
   name: (identifier) @id
)@func
```

However, it no longer works when we capture multiple nodes with the same name, in queries like this

```
(class_definition
   body: (block
      (function_definition)+ @funcs
   )
)@myclass
```

In the following, the content of `@funcs` must have multiple values.

## What is your solution?

In the node, we introduce `capturesList` that contains the list of all values for a given capture name. All ast elements for a capture name will be in the list.

We added a test to show how this list works (see `TsQueryListTest`).


## Alternatives considered

Do not have the `capturesList` and instead, add a list in the existing `captures` object. However, it seems it will be too confusing for the end user. We may change this in the future if we experience issues.

## What the reviewer should know

1. For a tree-sitter query, the `node` will have the `capturesList` attribute. This will be a map which key is a string (name of the capture) and the value is a list of astelement. @raczosala should add typing support in the editor for it
2. We added the helper function `getCodeForNode`