### PR TITLE
Avoid parsing code for each rule

### DIFF
--- a/cli/src/main/java/io/codiga/cli/Main.java
+++ b/cli/src/main/java/io/codiga/cli/Main.java
@@ -69,7 +69,7 @@ public class Main {
     System.out.println("============");
     rules.forEach(
         r -> {
-          System.out.println(r.name());
+          System.out.println(r.name);
         });
   }
 
@@ -228,10 +228,10 @@ public class Main {
     }
 
     // ignore paths and configuration specified = no analysis
-    if (!ignorePaths.isEmpty() && configurationFile.isPresent()) {
-      System.err.println("cannot specify ignore path when a configuration file is detected");
-      System.exit(1);
-    }
+//    if (!ignorePaths.isEmpty() && configurationFile.isPresent()) {
+//      System.err.println("cannot specify ignore path when a configuration file is detected");
+//      System.exit(1);
+//    }
 
     // read the rules
     List<AnalyzerRule> rules = List.of();
@@ -312,7 +312,7 @@ public class Main {
 
       // Get the list of rules for this language
       List<AnalyzerRule> rulesForLanguage =
-          rules.stream().filter(r -> r.language() == entry.getKey()).toList();
+          rules.stream().filter(r -> r.language == entry.getKey()).toList();
 
       // For each file
       for (Path path : filesForLanguage) {
@@ -333,7 +333,7 @@ public class Main {
                   .get(i)
                   .forEach(
                       r -> {
-                        System.out.printf("   %s%n", r.name());
+                        System.out.printf("   %s%n", r.name);
                       });
             }
           }

--- a/cli/src/main/java/io/codiga/cli/model/sarif/SarifRun.java
+++ b/cli/src/main/java/io/codiga/cli/model/sarif/SarifRun.java
@@ -3,12 +3,11 @@ package io.codiga.cli.model.sarif;
 import io.codiga.analyzer.rule.AnalyzerRule;
 import io.codiga.cli.model.ViolationWithFilename;
 import io.codiga.model.error.RuleResult;
-import lombok.Builder;
-
 import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import lombok.Builder;
 
 /**
  * Describes a single run of an analysis tool, and contains the reported output of that run.
@@ -46,7 +45,7 @@ public class SarifRun {
         int index = 0;
         Map<String, Integer> ruleNameToRuleIndex = new HashMap<>();
         for (AnalyzerRule rule : rules) {
-            ruleNameToRuleIndex.put(rule.name(), index);
+            ruleNameToRuleIndex.put(rule.name, index);
             index = index + 1;
         }
         return ruleNameToRuleIndex;

--- a/cli/src/main/java/io/codiga/cli/model/sarif/SarifToolDriverRule.java
+++ b/cli/src/main/java/io/codiga/cli/model/sarif/SarifToolDriverRule.java
@@ -19,9 +19,9 @@ public class SarifToolDriverRule {
     public static SarifToolDriverRule fromAnalyzerRule(AnalyzerRule analyzerRule) {
         return SarifToolDriverRule
                 .builder()
-                .fullDescription(SarifMultiformatMessage.from(analyzerRule.description()))
-                .helpUri(String.format("https://static-analysis.datadoghq.com/%s", analyzerRule.name()))
-                .id(analyzerRule.name())
+                .fullDescription(SarifMultiformatMessage.from(analyzerRule.description))
+                .helpUri(String.format("https://static-analysis.datadoghq.com/%s", analyzerRule.name))
+                .id(analyzerRule.name)
                 .build();
     }
 }

--- a/cli/src/main/java/io/codiga/cli/utils/DatadogUtils.java
+++ b/cli/src/main/java/io/codiga/cli/utils/DatadogUtils.java
@@ -31,8 +31,6 @@ public class DatadogUtils {
      * @return
      */
     public static Optional<AnalyzerRule> getRuleFromJson(JsonNode node, String rulesetName) {
-        System.out.println(node.toString());
-
         ObjectMapper mapper = new ObjectMapper();
         mapper.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
 
@@ -53,12 +51,22 @@ public class DatadogUtils {
                 String decodedDescription = description != null ? new String(Base64.getDecoder().decode(description.asText())) : null;
                 String decodedRegex = regex != null ? new String(Base64.getDecoder().decode(regex.asText())) : null;
                 String decodedTreeSitterQuery = treeSitterQuery != null ? new String(Base64.getDecoder().decode(treeSitterQuery.asText())) : null;
-
-                return Optional.of(
-                    new AnalyzerRule(String.format("%s/%s", rulesetName, res.name()), decodedDescription, res.language(), res.type(), res.entityChecked(), decodedCode, decodedRegex, decodedTreeSitterQuery, res.variables())
-                );
+                var analysisRule = AnalyzerRule
+                    .builder()
+                    .name(String.format("%s/%s", rulesetName, res.name))
+                    .description(decodedDescription)
+                    .language(res.language)
+                    .entityChecked(res.entityChecked)
+                    .code(decodedCode)
+                    .type(res.type)
+                    .regex(decodedRegex)
+                    .treeSitterQuery(decodedTreeSitterQuery)
+                    .variables(res.variables)
+                    .build();
+                return Optional.of(analysisRule);
             }
         } catch (IllegalArgumentException e) {
+            e.printStackTrace();
             System.err.println(String.format("error when trying to convert rule from ruleset %s", rulesetName));
         }
         return Optional.empty();

--- a/cli/src/main/java/io/codiga/cli/utils/RulesUtils.java
+++ b/cli/src/main/java/io/codiga/cli/utils/RulesUtils.java
@@ -17,11 +17,22 @@ public class RulesUtils {
     public static List<AnalyzerRule> getRulesFromFile(String path) throws IOException {
         ObjectMapper mapper = new ObjectMapper();
         return mapper.readValue(new File(path), Rules.class).rules.stream().map(r -> {
-            String decodedCode = new String(Base64.getDecoder().decode(r.code()));
-            String decodedDescription = r.description() != null ? new String(Base64.getDecoder().decode(r.description())):"";
-            String decodedRegex = r.regex() != null ? new String(Base64.getDecoder().decode(r.regex())):null;
-            String decodedTreeSitterQuery = r.treeSitterQuery() != null ? new String(Base64.getDecoder().decode(r.treeSitterQuery())):null;
-            return new AnalyzerRule(r.name(), decodedDescription, r.language(), r.type(), r.entityChecked(), decodedCode, decodedRegex, decodedTreeSitterQuery, r.variables());
+            String decodedCode = new String(Base64.getDecoder().decode(r.code));
+            String decodedDescription = r.description != null ? new String(Base64.getDecoder().decode(r.description)):"";
+            String decodedRegex = r.regex != null ? new String(Base64.getDecoder().decode(r.regex)):null;
+            String decodedTreeSitterQuery = r.treeSitterQuery != null ? new String(Base64.getDecoder().decode(r.treeSitterQuery)):null;
+            return AnalyzerRule
+                .builder()
+                .name(r.name)
+                .description(decodedDescription)
+                .language(r.language)
+                .type(r.type)
+                .entityChecked(r.entityChecked)
+                .code(decodedCode)
+                .regex(decodedRegex)
+                .treeSitterQuery(decodedTreeSitterQuery)
+                .variables(r.variables)
+                .build();
         }).collect(Collectors.toList());
     }
 

--- a/core/src/main/java/io/codiga/analyzer/Analyzer.java
+++ b/core/src/main/java/io/codiga/analyzer/Analyzer.java
@@ -1,5 +1,10 @@
 package io.codiga.analyzer;
 
+import static io.codiga.metrics.MetricsName.*;
+import static io.codiga.model.RuleErrorCode.ERROR_RULE_INVALID_RULE_TYPE;
+import static io.codiga.model.RuleErrorCode.ERROR_RULE_LANGUAGE_MISMATCH;
+import static io.codiga.utils.CompletableFutureUtils.sequence;
+
 import com.google.common.collect.ImmutableList;
 import io.codiga.analyzer.ast.languages.javascript.JavaScriptAnalyzer;
 import io.codiga.analyzer.ast.languages.python.PythonAnalyzer;
@@ -15,109 +20,158 @@ import io.codiga.model.RuleType;
 import io.codiga.model.error.AnalysisResult;
 import io.codiga.model.error.RuleResult;
 import io.codiga.parser.treesitter.utils.TreeSitterInit;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.io.FileNotFoundException;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
-
-import static io.codiga.metrics.MetricsName.*;
-import static io.codiga.model.RuleErrorCode.ERROR_RULE_INVALID_RULE_TYPE;
-import static io.codiga.model.RuleErrorCode.ERROR_RULE_LANGUAGE_MISMATCH;
-import static io.codiga.utils.CompletableFutureUtils.sequence;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
- * This is the central analyzer. It receives requests to analyze code and dispatch
- * to the appropriate language-specific analyzer.
+ * This is the central analyzer. It receives requests to analyze code and dispatch to the
+ * appropriate language-specific analyzer.
  */
 public class Analyzer {
 
-    private final MetricsInterface metrics;
-    private final ErrorReportingInterface errorReporting;
-    Logger logger = LoggerFactory.getLogger(Analyzer.class);
-    PythonAnalyzer pythonAnalyzer;
-    JavaScriptAnalyzer javaScriptAnalyzer;
-    TypeScriptAnalyzer typeScriptAnalyzer;
-    PatternAnalyzer patternAnalyzer;
-    TreeSitterPatternMatching treeSitterPatternMatching;
+  private final MetricsInterface metrics;
+  private final ErrorReportingInterface errorReporting;
+  Logger logger = LoggerFactory.getLogger(Analyzer.class);
+  PythonAnalyzer pythonAnalyzer;
+  JavaScriptAnalyzer javaScriptAnalyzer;
+  TypeScriptAnalyzer typeScriptAnalyzer;
+  PatternAnalyzer patternAnalyzer;
+  TreeSitterPatternMatching treeSitterPatternMatching;
 
-    public Analyzer(ErrorReportingInterface errorReporting, MetricsInterface metrics, AnalyzerConfiguration configuration) {
-        this.errorReporting = errorReporting;
-        this.metrics = metrics;
-        this.patternAnalyzer = new PatternAnalyzer(this.metrics, this.errorReporting, configuration);
-        this.treeSitterPatternMatching = new TreeSitterPatternMatching(this.metrics, this.errorReporting, configuration);
-        this.pythonAnalyzer = new PythonAnalyzer(this.metrics, this.errorReporting, configuration);
-        this.javaScriptAnalyzer = new JavaScriptAnalyzer(this.metrics, this.errorReporting, configuration);
-        this.typeScriptAnalyzer = new TypeScriptAnalyzer(this.metrics, this.errorReporting, configuration);
+  public Analyzer(
+      ErrorReportingInterface errorReporting,
+      MetricsInterface metrics,
+      AnalyzerConfiguration configuration) {
+    this.errorReporting = errorReporting;
+    this.metrics = metrics;
+    this.patternAnalyzer = new PatternAnalyzer(this.metrics, this.errorReporting, configuration);
+    this.treeSitterPatternMatching =
+        new TreeSitterPatternMatching(this.metrics, this.errorReporting, configuration);
+    this.pythonAnalyzer = new PythonAnalyzer(this.metrics, this.errorReporting, configuration);
+    this.javaScriptAnalyzer =
+        new JavaScriptAnalyzer(this.metrics, this.errorReporting, configuration);
+    this.typeScriptAnalyzer =
+        new TypeScriptAnalyzer(this.metrics, this.errorReporting, configuration);
 
-        try {
-            TreeSitterInit.init();
-        } catch (FileNotFoundException fileNotFoundException) {
-            logger.info("Shared library not found");
-        }
+    try {
+      TreeSitterInit.init();
+    } catch (FileNotFoundException fileNotFoundException) {
+      logger.info("Shared library not found");
+    }
+  }
 
+  public CompletableFuture<AnalysisResult> analyze(
+      Language language,
+      String filename,
+      String code,
+      List<AnalyzerRule> rules,
+      AnalysisOptions options) {
+    long startAnalysisTimestampMs = System.currentTimeMillis();
+    // Distinguish between rules with valid languages and invalid ones.
+    List<AnalyzerRule> rulesWithValidLanguage =
+        rules.stream().filter(f -> f.validForLanguage(language)).toList();
+    List<AnalyzerRule> rulesWithValidLanguageForAst =
+        rulesWithValidLanguage.stream().filter(r -> r.type == RuleType.AST_CHECK).toList();
+    List<AnalyzerRule> rulesWithValidLanguageForPattern =
+        rulesWithValidLanguage.stream()
+            .filter(r -> r.type == RuleType.REGEX && r.regex != null)
+            .toList();
+    List<AnalyzerRule> rulesWithValidLanguageForTreeSitterPatternMatching =
+        rulesWithValidLanguage.stream()
+            .filter(r -> r.type == RuleType.TREE_SITTER_QUERY && r.treeSitterQuery != null)
+            .toList();
+
+    List<AnalyzerRule> rulesWithInvalidLanguage =
+        rules.stream().filter(f -> !f.validForLanguage(language)).toList();
+    CompletableFuture<AnalysisResult> completedResultForAst;
+
+    // First, AST analysis
+    switch (language) {
+      case PYTHON:
+        completedResultForAst =
+            pythonAnalyzer.analyze(language, filename, code, rulesWithValidLanguageForAst, options);
+        break;
+      case JAVASCRIPT:
+        completedResultForAst =
+            javaScriptAnalyzer.analyze(
+                language, filename, code, rulesWithValidLanguageForAst, options);
+        break;
+      case TYPESCRIPT:
+        completedResultForAst =
+            typeScriptAnalyzer.analyze(
+                language, filename, code, rulesWithValidLanguageForAst, options);
+        break;
+      default:
+        completedResultForAst = CompletableFuture.completedFuture(new AnalysisResult(List.of()));
+        break;
     }
 
-    public CompletableFuture<AnalysisResult> analyze(Language language, String filename, String code, List<AnalyzerRule> rules, AnalysisOptions options) {
-        long startAnalysisTimestampMs = System.currentTimeMillis();
-        // Distinguish between rules with valid languages and invalid ones.
-        List<AnalyzerRule> rulesWithValidLanguage = rules.stream().filter(f -> f.validForLanguage(language)).toList();
-        List<AnalyzerRule> rulesWithValidLanguageForAst = rulesWithValidLanguage.stream().filter(r -> r.type() == RuleType.AST_CHECK).toList();
-        List<AnalyzerRule> rulesWithValidLanguageForPattern = rulesWithValidLanguage.stream().filter(r -> r.type() == RuleType.REGEX && r.regex() != null).toList();
-        List<AnalyzerRule> rulesWithValidLanguageForTreeSitterPatternMatching = rulesWithValidLanguage.stream().filter(r -> r.type() == RuleType.TREE_SITTER_QUERY && r.treeSitterQuery() != null).toList();
+    // Second, pattern analysis
+    CompletableFuture<AnalysisResult> patternAnalysis =
+        patternAnalyzer.analyze(
+            language, filename, code, rulesWithValidLanguageForPattern, options);
 
+    // Finally, tree sitter pattern matching
+    CompletableFuture<AnalysisResult> treeSitterPatternMatchingAnalysis =
+        treeSitterPatternMatching.analyze(
+            language, filename, code, rulesWithValidLanguageForTreeSitterPatternMatching, options);
 
-        List<AnalyzerRule> rulesWithInvalidLanguage = rules.stream().filter(f -> !f.validForLanguage(language)).toList();
-        CompletableFuture<AnalysisResult> completedResultForAst;
+    CompletableFuture<List<AnalysisResult>> allFutures =
+        sequence(
+            List.of(patternAnalysis, completedResultForAst, treeSitterPatternMatchingAnalysis));
 
+    // Return an error for the rule with an invalid language
+    return allFutures.thenApply(
+        result -> {
+          List<RuleResult> invalidLanguagesRuleResults =
+              rulesWithInvalidLanguage.stream()
+                  .map(
+                      r ->
+                          new RuleResult(
+                              r.name,
+                              List.of(),
+                              List.of(ERROR_RULE_LANGUAGE_MISMATCH),
+                              null,
+                              null,
+                              0))
+                  .toList();
 
-        // First, AST analysis
-        switch (language) {
-            case PYTHON:
-                completedResultForAst = pythonAnalyzer.analyze(language, filename, code, rulesWithValidLanguageForAst, options);
-                break;
-            case JAVASCRIPT:
-                completedResultForAst = javaScriptAnalyzer.analyze(language, filename, code, rulesWithValidLanguageForAst, options);
-                break;
-            case TYPESCRIPT:
-                completedResultForAst = typeScriptAnalyzer.analyze(language, filename, code, rulesWithValidLanguageForAst, options);
-                break;
-            default:
-                completedResultForAst = CompletableFuture.completedFuture(new AnalysisResult(List.of()));
-                break;
-        }
+          List<RuleResult> invalidRuleTypeResults =
+              rulesWithValidLanguage.stream()
+                  .filter(r -> r.type == RuleType.UNKNOWN)
+                  .map(
+                      r ->
+                          new RuleResult(
+                              r.name,
+                              List.of(),
+                              List.of(ERROR_RULE_INVALID_RULE_TYPE),
+                              null,
+                              null,
+                              0))
+                  .toList();
 
-        // Second, pattern analysis
-        CompletableFuture<AnalysisResult> patternAnalysis = patternAnalyzer.analyze(language, filename, code, rulesWithValidLanguageForPattern, options);
-
-        // Finally, tree sitter pattern matching
-        CompletableFuture<AnalysisResult> treeSitterPatternMatchingAnalysis = treeSitterPatternMatching.analyze(language, filename, code, rulesWithValidLanguageForTreeSitterPatternMatching, options);
-
-        CompletableFuture<List<AnalysisResult>> allFutures = sequence(List.of(patternAnalysis, completedResultForAst, treeSitterPatternMatchingAnalysis));
-
-        // Return an error for the rule with an invalid language
-        return allFutures.thenApply(result -> {
-            List<RuleResult> invalidLanguagesRuleResults = rulesWithInvalidLanguage.stream().map(r -> new RuleResult(r.name(), List.of(), List.of(ERROR_RULE_LANGUAGE_MISMATCH), null, null, 0)).toList();
-
-            List<RuleResult> invalidRuleTypeResults = rulesWithValidLanguage.stream()
-                .filter(r -> r.type() == RuleType.UNKNOWN)
-                .map(r -> new RuleResult(r.name(), List.of(), List.of(ERROR_RULE_INVALID_RULE_TYPE), null, null, 0)).toList();
-
-            List<RuleResult> allRuleResult = ImmutableList
-                .<RuleResult>builder()
-                .addAll(result.stream().flatMap(r -> r.ruleResults().stream()).toList())
-                .addAll(invalidLanguagesRuleResults)
-                .addAll(invalidRuleTypeResults)
-                .build();
-            long endAnalysisTimestampMs = System.currentTimeMillis();
-            long analysisTimeMs = endAnalysisTimestampMs - startAnalysisTimestampMs;
-            // Total analysis time
-            metrics.histogramValue(METRIC_HISTOGRAM_REQUEST_ANALYSIS_TIME_TOTAL, analysisTimeMs);
-            metrics.recordDistribution(METRIC_DISTRIBUTION_ANALYSIS_TOTAL_TIME, analysisTimeMs);
-            // Analysis time per language
-            metrics.recordDistribution(String.format("%s-%s", METRIC_DISTRIBUTION_ANALYSIS_TIME_PER_LANGUAGE, language.toString().toLowerCase()), analysisTimeMs);
-            return new AnalysisResult(allRuleResult);
+          List<RuleResult> allRuleResult =
+              ImmutableList.<RuleResult>builder()
+                  .addAll(result.stream().flatMap(r -> r.ruleResults().stream()).toList())
+                  .addAll(invalidLanguagesRuleResults)
+                  .addAll(invalidRuleTypeResults)
+                  .build();
+          long endAnalysisTimestampMs = System.currentTimeMillis();
+          long analysisTimeMs = endAnalysisTimestampMs - startAnalysisTimestampMs;
+          // Total analysis time
+          metrics.histogramValue(METRIC_HISTOGRAM_REQUEST_ANALYSIS_TIME_TOTAL, analysisTimeMs);
+          metrics.recordDistribution(METRIC_DISTRIBUTION_ANALYSIS_TOTAL_TIME, analysisTimeMs);
+          // Analysis time per language
+          metrics.recordDistribution(
+              String.format(
+                  "%s-%s",
+                  METRIC_DISTRIBUTION_ANALYSIS_TIME_PER_LANGUAGE,
+                  language.toString().toLowerCase()),
+              analysisTimeMs);
+          return new AnalysisResult(allRuleResult);
         });
-    }
+  }
 }

--- a/core/src/main/java/io/codiga/analyzer/ast/common/AnalyzerCommon.java
+++ b/core/src/main/java/io/codiga/analyzer/ast/common/AnalyzerCommon.java
@@ -1,5 +1,12 @@
 package io.codiga.analyzer.ast.common;
 
+import static io.codiga.analyzer.ast.vm.VmUtils.formatVmErrorMessage;
+import static io.codiga.metrics.MetricsName.METRIC_HISTOGRAM_REQUEST_ANALYSIS_TIME_PREFIX;
+import static io.codiga.metrics.MetricsName.METRIC_RULE_EXECUTION_UNKNOWN_ERROR;
+import static io.codiga.model.RuleErrorCode.*;
+import static io.codiga.utils.EnvironmentUtils.ANALYSIS_TIMEOUT;
+import static io.codiga.utils.EnvironmentUtils.getEnvironmentValueAsLong;
+
 import datadog.trace.api.Trace;
 import io.codiga.analyzer.AnalysisOptions;
 import io.codiga.analyzer.AnalyzerFuturePool;
@@ -12,10 +19,6 @@ import io.codiga.model.ast.common.AstElement;
 import io.codiga.model.error.AnalysisResult;
 import io.codiga.model.error.RuleResult;
 import io.codiga.model.error.Violation;
-import org.graalvm.polyglot.PolyglotException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -25,164 +28,268 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.regex.PatternSyntaxException;
 import java.util.stream.Collectors;
-
-import static io.codiga.analyzer.ast.vm.VmUtils.formatVmErrorMessage;
-import static io.codiga.metrics.MetricsName.METRIC_HISTOGRAM_REQUEST_ANALYSIS_TIME_PREFIX;
-import static io.codiga.metrics.MetricsName.METRIC_RULE_EXECUTION_UNKNOWN_ERROR;
-import static io.codiga.model.RuleErrorCode.*;
-import static io.codiga.utils.EnvironmentUtils.ANALYSIS_TIMEOUT;
-import static io.codiga.utils.EnvironmentUtils.getEnvironmentValueAsLong;
-
+import org.graalvm.polyglot.PolyglotException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public abstract class AnalyzerCommon {
 
+  public static final String COMMENT_SHARP = "#";
+  public static final String COMMENT_TWO_SLASHES = "//";
+  protected final MetricsInterface metrics;
+  private final Logger logger = LoggerFactory.getLogger(AnalyzerCommon.class);
+  private final AnalyzerFuturePool pool = AnalyzerFuturePool.getInstance();
+  private final ErrorReportingInterface errorReporting;
+  private final AnalyzerConfiguration analyzerConfiguration;
 
-    public final static String COMMENT_SHARP = "#";
-    public final static String COMMENT_TWO_SLASHES = "//";
-    protected final MetricsInterface metrics;
-    private final Logger logger = LoggerFactory.getLogger(AnalyzerCommon.class);
-    private final AnalyzerFuturePool pool = AnalyzerFuturePool.getInstance();
-    private final ErrorReportingInterface errorReporting;
-    private final AnalyzerConfiguration analyzerConfiguration;
+  public AnalyzerCommon(
+      MetricsInterface metrics,
+      ErrorReportingInterface errorReporting,
+      AnalyzerConfiguration configuration) {
+    this.metrics = metrics;
+    this.errorReporting = errorReporting;
+    this.analyzerConfiguration = configuration;
+  }
 
-    public AnalyzerCommon(MetricsInterface metrics, ErrorReportingInterface errorReporting, AnalyzerConfiguration configuration) {
-        this.metrics = metrics;
-        this.errorReporting = errorReporting;
-        this.analyzerConfiguration = configuration;
+  protected long getTimeoutMs() {
+    return getEnvironmentValueAsLong(ANALYSIS_TIMEOUT)
+        .orElse(this.analyzerConfiguration.analysisTimeoutMs);
+  }
+
+  public List<Long> getCommentsLine(String code, String commentStart) {
+    String commentLine = String.format("%scodiga-disable", commentStart);
+
+    ArrayList<Long> comments = new ArrayList<>();
+    Scanner scanner = new Scanner(code);
+    long lineNumber = 1;
+    while (scanner.hasNextLine()) {
+      String line = scanner.nextLine();
+      String lineStripped = line.replaceAll(" ", "");
+      if (lineStripped.equalsIgnoreCase(commentLine)) {
+        comments.add(lineNumber);
+      }
+      lineNumber = lineNumber + 1;
     }
+    scanner.close();
+    return comments;
+  }
 
+  /**
+   * Inject rule variables into an AST node's context
+   *
+   * @param elements
+   * @param variables
+   */
+  public static void addVariablesToElements(
+      List<AstElement> elements, Map<String, String> variables) {
+    Map<String, String> variablesToInject = variables == null ? Map.of() : variables;
+    elements.forEach(astElement -> astElement.context.setVariables(variablesToInject));
+  }
 
-    protected long getTimeoutMs() {
-        return getEnvironmentValueAsLong(ANALYSIS_TIMEOUT).orElse(this.analyzerConfiguration.analysisTimeoutMs);
+  public String getCommentsSymbol(Language language) {
+    if (language == Language.PYTHON) {
+      return COMMENT_SHARP;
     }
-
-    public List<Long> getCommentsLine(String code, String commentStart) {
-        String commentLine = String.format("%scodiga-disable", commentStart);
-
-        ArrayList<Long> comments = new ArrayList<>();
-        Scanner scanner = new Scanner(code);
-        long lineNumber = 1;
-        while (scanner.hasNextLine()) {
-            String line = scanner.nextLine();
-            String lineStripped = line.replaceAll(" ", "");
-            if (lineStripped.equalsIgnoreCase(commentLine)) {
-                comments.add(lineNumber);
-            }
-            lineNumber = lineNumber + 1;
-        }
-        scanner.close();
-        return comments;
-
+    if (language == Language.JAVASCRIPT) {
+      return COMMENT_TWO_SLASHES;
     }
-
-    /**
-     * Inject rule variables into an AST node's context
-     * @param elements
-     * @param variables
-     */
-    public static void addVariablesToElements(List<AstElement> elements, Map<String, String> variables) {
-        Map<String, String> variablesToInject = variables == null ? Map.of() : variables;
-        elements.forEach(astElement -> astElement.context.setVariables(variablesToInject));
+    if (language == Language.TYPESCRIPT) {
+      return COMMENT_TWO_SLASHES;
     }
+    return COMMENT_TWO_SLASHES;
+  }
 
-    public String getCommentsSymbol(Language language) {
-        if (language == Language.PYTHON) {
-            return COMMENT_SHARP;
-        }
-        if (language == Language.JAVASCRIPT) {
-            return COMMENT_TWO_SLASHES;
-        }
-        if (language == Language.TYPESCRIPT) {
-            return COMMENT_TWO_SLASHES;
-        }
-        return COMMENT_TWO_SLASHES;
-    }
+  public abstract RuleResult execute(AnalyzerContext analyzerContext, AnalyzerRule rule);
 
-    public abstract RuleResult execute(AnalyzerContext analyzerContext, AnalyzerRule rule);
+  public abstract AnalyzerContext buildContext(
+      Language language,
+      String filename,
+      String code,
+      List<AnalyzerRule> rules,
+      AnalysisOptions options);
 
-    public abstract AnalyzerContext buildContext(Language language, String filename, String code, List<AnalyzerRule> rules, AnalysisOptions options);
+  @Trace(operationName = "AnalyzerCommon.analyze")
+  public CompletableFuture<AnalysisResult> analyze(
+      Language language,
+      String filename,
+      String code,
+      List<AnalyzerRule> rules,
+      AnalysisOptions options) {
+    long timeoutMs = getTimeoutMs();
+    // Get the lines to ignore that have codiga-disable
+    List<Long> linesToIgnore = getCommentsLine(code, getCommentsSymbol(language));
 
-    @Trace(operationName = "AnalyzerCommon.analyze")
-    public CompletableFuture<AnalysisResult> analyze(Language language, String filename, String code, List<AnalyzerRule> rules, AnalysisOptions options) {
-        long timeoutMs = getTimeoutMs();
-        // Get the lines to ignore that have codiga-disable
-        List<Long> linesToIgnore = getCommentsLine(code, getCommentsSymbol(language));
+    // Build execution, get the parser if this is an AST rule.
+    AnalyzerContext analyzerContext = buildContext(language, filename, code, rules, options);
 
-        // Build execution, get the parser if this is an AST rule.
-        AnalyzerContext analyzerContext = buildContext(language, filename, code, rules, options);
-
-        CompletableFuture<AnalysisResult> result = CompletableFuture.supplyAsync(() -> {
-                List<RuleResult> ruleResults = rules.stream().map(rule -> {
-                    long startTime = System.currentTimeMillis();
-                    try {
-                        RuleResult res = execute(analyzerContext, rule);
-                        long endTime = System.currentTimeMillis();
-                        long executionTime = endTime - startTime;
-                        String metricName = String.format("%s-%s", METRIC_HISTOGRAM_REQUEST_ANALYSIS_TIME_PREFIX, rule.name());
-                        metrics.histogramValue(metricName, (double) executionTime);
-//                        logger.info(String.format("rule %s took %s ms to execute", rule.name(), executionTime));
-                        return res;
-                    } catch (PatternSyntaxException patternSyntaxException) {
-                        logger.error(String.format("reporting rule %s as invalid-regex", rule.name()));
-                        return new RuleResult(rule.name(), List.of(), List.of(ERROR_INVALID_REGEX), null, null, 0);
-                    } catch (PolyglotException polyglotException) {
-                        long endTime = System.currentTimeMillis();
-                        long executionTime = endTime - startTime;
-                        if (polyglotException.getMessage() != null && polyglotException.getMessage().contains("Statement count limit of") && polyglotException.getMessage().contains("Statements executed")) {
-                            logger.info(String.format("rule %s timedout because of instructions", rule.name()));
-                            return new RuleResult(rule.name(), List.of(), List.of(ERROR_RULE_TIMEOUT), null, null, executionTime);
-                        }
-                        String executionMessage = "unknown error";
-                        if (polyglotException.getMessage() != null) {
-                            executionMessage = formatVmErrorMessage(polyglotException.getMessage());
-                        }
-                        logger.error(String.format("reporting rule %s as execution error", rule.name()));
-                        polyglotException.printStackTrace();
-                        return new RuleResult(rule.name(), List.of(), List.of(ERROR_RULE_EXECUTION), executionMessage, null, executionTime);
-                    } catch (Exception unknownException) {
-                        long endTime = System.currentTimeMillis();
-                        long executionTime = endTime - startTime;
-                        this.metrics.incrementMetric(METRIC_RULE_EXECUTION_UNKNOWN_ERROR);
-                        this.errorReporting.reportError(unknownException, String.format("error unknown exception rule %s", rule.name()));
-                        return new RuleResult(rule.name(), List.of(), List.of(ERROR_RULE_UNKNOWN), unknownException.getMessage(), null, executionTime);
-                    }
-
-                }).collect(Collectors.toList());
-                return ruleResults;
-            }, pool.service)
-            .thenApply(finalList -> {
-                // ignore the violations being ignored
-                List<RuleResult> fileteredList = finalList.stream().map(ruleResult -> {
-                    List<Violation> filteredViolations = ruleResult.violations().stream().filter(v -> {
-                        if (v.start != null) {
-                            long previousLine = v.start.line - 1;
-                            return !linesToIgnore.contains(previousLine);
-                        }
-                        return false;
-                    }).toList();
-                    if (ruleResult.output() != null) {
-                        logger.debug(String.format("Output for rule %s: %s", ruleResult.identifier(), ruleResult.output()));
-                    }
-                    return new RuleResult(ruleResult.identifier(), filteredViolations, ruleResult.errors(), ruleResult.executionError(), ruleResult.output(), ruleResult.executionTimeMs());
-                }).toList();
-                return new AnalysisResult(fileteredList);
-            })
+    CompletableFuture<AnalysisResult> result =
+        CompletableFuture.supplyAsync(
+                () -> {
+                  List<RuleResult> ruleResults =
+                      rules.stream()
+                          .map(
+                              rule -> {
+                                long startTime = System.currentTimeMillis();
+                                try {
+                                  RuleResult res = execute(analyzerContext, rule);
+                                  long endTime = System.currentTimeMillis();
+                                  long executionTime = endTime - startTime;
+                                  String metricName =
+                                      String.format(
+                                          "%s-%s",
+                                          METRIC_HISTOGRAM_REQUEST_ANALYSIS_TIME_PREFIX, rule.name);
+                                  metrics.histogramValue(metricName, (double) executionTime);
+                                  //                        logger.info(String.format("rule %s took
+                                  // %s ms to execute", rule.name(), executionTime));
+                                  return res;
+                                } catch (PatternSyntaxException patternSyntaxException) {
+                                  logger.error(
+                                      String.format(
+                                          "reporting rule %s as invalid-regex", rule.name));
+                                  return new RuleResult(
+                                      rule.name,
+                                      List.of(),
+                                      List.of(ERROR_INVALID_REGEX),
+                                      null,
+                                      null,
+                                      0);
+                                } catch (PolyglotException polyglotException) {
+                                  long endTime = System.currentTimeMillis();
+                                  long executionTime = endTime - startTime;
+                                  if (polyglotException.getMessage() != null
+                                      && polyglotException
+                                          .getMessage()
+                                          .contains("Statement count limit of")
+                                      && polyglotException
+                                          .getMessage()
+                                          .contains("Statements executed")) {
+                                    logger.info(
+                                        String.format(
+                                            "rule %s timedout because of instructions", rule.name));
+                                    return new RuleResult(
+                                        rule.name,
+                                        List.of(),
+                                        List.of(ERROR_RULE_TIMEOUT),
+                                        null,
+                                        null,
+                                        executionTime);
+                                  }
+                                  String executionMessage = "unknown error";
+                                  if (polyglotException.getMessage() != null) {
+                                    executionMessage =
+                                        formatVmErrorMessage(polyglotException.getMessage());
+                                  }
+                                  logger.error(
+                                      String.format(
+                                          "reporting rule %s as execution error", rule.name));
+                                  polyglotException.printStackTrace();
+                                  return new RuleResult(
+                                      rule.name,
+                                      List.of(),
+                                      List.of(ERROR_RULE_EXECUTION),
+                                      executionMessage,
+                                      null,
+                                      executionTime);
+                                } catch (Exception unknownException) {
+                                  long endTime = System.currentTimeMillis();
+                                  long executionTime = endTime - startTime;
+                                  this.metrics.incrementMetric(METRIC_RULE_EXECUTION_UNKNOWN_ERROR);
+                                  this.errorReporting.reportError(
+                                      unknownException,
+                                      String.format("error unknown exception rule %s", rule.name));
+                                  return new RuleResult(
+                                      rule.name,
+                                      List.of(),
+                                      List.of(ERROR_RULE_UNKNOWN),
+                                      unknownException.getMessage(),
+                                      null,
+                                      executionTime);
+                                }
+                              })
+                          .collect(Collectors.toList());
+                  return ruleResults;
+                },
+                pool.service)
+            .thenApply(
+                finalList -> {
+                  // ignore the violations being ignored
+                  List<RuleResult> fileteredList =
+                      finalList.stream()
+                          .map(
+                              ruleResult -> {
+                                List<Violation> filteredViolations =
+                                    ruleResult.violations().stream()
+                                        .filter(
+                                            v -> {
+                                              if (v.start != null) {
+                                                long previousLine = v.start.line - 1;
+                                                return !linesToIgnore.contains(previousLine);
+                                              }
+                                              return false;
+                                            })
+                                        .toList();
+                                if (ruleResult.output() != null) {
+                                  logger.debug(
+                                      String.format(
+                                          "Output for rule %s: %s",
+                                          ruleResult.identifier(), ruleResult.output()));
+                                }
+                                return new RuleResult(
+                                    ruleResult.identifier(),
+                                    filteredViolations,
+                                    ruleResult.errors(),
+                                    ruleResult.executionError(),
+                                    ruleResult.output(),
+                                    ruleResult.executionTimeMs());
+                              })
+                          .toList();
+                  return new AnalysisResult(fileteredList);
+                })
             .orTimeout(timeoutMs, TimeUnit.MILLISECONDS)
-            .exceptionally(exception -> {
-                if (exception instanceof TimeoutException) {
-                    logger.error(String.format("analysis for rules %s timeout", String.join(",", rules.stream().map(r -> r.name()).toList())));
-                    List<RuleResult> timedoutRuleResults = rules.stream().map(r -> {
-                        return new RuleResult(r.name(), List.of(), List.of(ERROR_RULE_TIMEOUT), null, null, timeoutMs);
-                    }).collect(Collectors.toList());
+            .exceptionally(
+                exception -> {
+                  if (exception instanceof TimeoutException) {
+                    logger.error(
+                        String.format(
+                            "analysis for rules %s timeout",
+                            String.join(",", rules.stream().map(r -> r.name).toList())));
+                    List<RuleResult> timedoutRuleResults =
+                        rules.stream()
+                            .map(
+                                r -> {
+                                  return new RuleResult(
+                                      r.name,
+                                      List.of(),
+                                      List.of(ERROR_RULE_TIMEOUT),
+                                      null,
+                                      null,
+                                      timeoutMs);
+                                })
+                            .collect(Collectors.toList());
                     return new AnalysisResult(timedoutRuleResults);
-                }
-                logger.error(String.format("analysis for rules %s report an error", String.join(",", rules.stream().map(r -> r.name()).toList())));
+                  }
+                  logger.error(
+                      String.format(
+                          "analysis for rules %s report an error",
+                          String.join(",", rules.stream().map(r -> r.name).toList())));
 
-                List<RuleResult> erroredRules = rules.stream().map(r -> {
-                    return new RuleResult(r.name(), List.of(), List.of(ERROR_RULE_UNKNOWN), exception.getCause() != null ? exception.getCause().getMessage() : exception.getMessage(), null, timeoutMs);
-                }).collect(Collectors.toList());
-                return new AnalysisResult(erroredRules);
-            });
-        return result;
-    }
+                  List<RuleResult> erroredRules =
+                      rules.stream()
+                          .map(
+                              r -> {
+                                return new RuleResult(
+                                    r.name,
+                                    List.of(),
+                                    List.of(ERROR_RULE_UNKNOWN),
+                                    exception.getCause() != null
+                                        ? exception.getCause().getMessage()
+                                        : exception.getMessage(),
+                                    null,
+                                    timeoutMs);
+                              })
+                          .collect(Collectors.toList());
+                  return new AnalysisResult(erroredRules);
+                });
+    return result;
+  }
 }

--- a/core/src/main/java/io/codiga/analyzer/ast/languages/javascript/JavaScriptAnalyzer.java
+++ b/core/src/main/java/io/codiga/analyzer/ast/languages/javascript/JavaScriptAnalyzer.java
@@ -1,5 +1,7 @@
 package io.codiga.analyzer.ast.languages.javascript;
 
+import static io.codiga.metrics.MetricsName.METRIC_DISTRIBUTION_PARSING_TIME_PER_LANGUAGE;
+
 import datadog.trace.api.Trace;
 import io.codiga.analyzer.AnalysisOptions;
 import io.codiga.analyzer.ast.common.AnalyzerCommon;
@@ -12,12 +14,9 @@ import io.codiga.metrics.MetricsInterface;
 import io.codiga.model.Language;
 import io.codiga.model.ast.common.AstElement;
 import io.codiga.model.error.RuleResult;
+import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.List;
-
-import static io.codiga.metrics.MetricsName.METRIC_DISTRIBUTION_PARSING_TIME_PER_LANGUAGE;
 
 public class JavaScriptAnalyzer extends AnalyzerCommon {
 
@@ -54,13 +53,13 @@ public class JavaScriptAnalyzer extends AnalyzerCommon {
 
         vmContext.initializeRule(rule);
 
-        List<AstElement> astElements = context.getElementsToCheck(rule.entityChecked());
+        List<AstElement> astElements = context.getElementsToCheck(rule.entityChecked);
 
-        addVariablesToElements(astElements, rule.variables());
+        addVariablesToElements(astElements, rule.variables);
 
         // no object to analyze, return directly and do not waste resource allocating a VM
         if (astElements.isEmpty()) {
-            return new RuleResult(rule.name(), List.of(), List.of(), null, null, 0);
+            return new RuleResult(rule.name, List.of(), List.of(), null, null, 0);
         }
 
         vmContext.prepareForExecution(analyzerContext, astElements);
@@ -73,7 +72,7 @@ public class JavaScriptAnalyzer extends AnalyzerCommon {
         vmContext.shutdown();
         long endTimestamp = System.currentTimeMillis();
         long executionTimeMs = endTimestamp - startTimestamp;
-        return new RuleResult(rule.name(), vmContext.getViolations(), List.of(), null, finalOutput, executionTimeMs);
+        return new RuleResult(rule.name, vmContext.getViolations(), List.of(), null, finalOutput, executionTimeMs);
     }
 
 

--- a/core/src/main/java/io/codiga/analyzer/ast/languages/python/PythonAnalyzer.java
+++ b/core/src/main/java/io/codiga/analyzer/ast/languages/python/PythonAnalyzer.java
@@ -1,5 +1,7 @@
 package io.codiga.analyzer.ast.languages.python;
 
+import static io.codiga.metrics.MetricsName.METRIC_DISTRIBUTION_PARSING_TIME_PER_LANGUAGE;
+
 import datadog.trace.api.Trace;
 import io.codiga.analyzer.AnalysisOptions;
 import io.codiga.analyzer.ast.common.AnalyzerCommon;
@@ -12,12 +14,9 @@ import io.codiga.metrics.MetricsInterface;
 import io.codiga.model.Language;
 import io.codiga.model.ast.common.AstElement;
 import io.codiga.model.error.RuleResult;
+import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.List;
-
-import static io.codiga.metrics.MetricsName.METRIC_DISTRIBUTION_PARSING_TIME_PER_LANGUAGE;
 
 public class PythonAnalyzer extends AnalyzerCommon {
 
@@ -54,13 +53,13 @@ public class PythonAnalyzer extends AnalyzerCommon {
 
         vmContext.initializeRule(rule);
 
-        List<AstElement> astElements = context.getElementsToCheck(rule.entityChecked());
+        List<AstElement> astElements = context.getElementsToCheck(rule.entityChecked);
 
-        addVariablesToElements(astElements, rule.variables());
+        addVariablesToElements(astElements, rule.variables);
 
         // no object to analyze, return directly and do not waste resource allocating a VM
         if (astElements.isEmpty()) {
-            return new RuleResult(rule.name(), List.of(), List.of(), null, null, 0);
+            return new RuleResult(rule.name, List.of(), List.of(), null, null, 0);
         }
 
         vmContext.prepareForExecution(analyzerContext, astElements);
@@ -74,7 +73,7 @@ public class PythonAnalyzer extends AnalyzerCommon {
         vmContext.shutdown();
         long endTimestamp = System.currentTimeMillis();
         long executionTimeMs = endTimestamp - startTimestamp;
-        return new RuleResult(rule.name(), vmContext.getViolations(), List.of(), null, finalOutput, executionTimeMs);
+        return new RuleResult(rule.name, vmContext.getViolations(), List.of(), null, finalOutput, executionTimeMs);
     }
 
 

--- a/core/src/main/java/io/codiga/analyzer/ast/languages/python/PythonAnalyzerContext.java
+++ b/core/src/main/java/io/codiga/analyzer/ast/languages/python/PythonAnalyzerContext.java
@@ -5,14 +5,9 @@ import io.codiga.analyzer.ast.common.AnalyzerContext;
 import io.codiga.analyzer.rule.AnalyzerRule;
 import io.codiga.model.EntityChecked;
 import io.codiga.model.Language;
-import io.codiga.parser.antlr.python.gen.PythonLexer;
-import io.codiga.parser.antlr.python.gen.PythonParser;
-import org.antlr.v4.runtime.CharStreams;
-import org.antlr.v4.runtime.CommonTokenStream;
+import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.List;
 
 public class PythonAnalyzerContext extends AnalyzerContext {
 
@@ -21,45 +16,23 @@ public class PythonAnalyzerContext extends AnalyzerContext {
 
     public PythonAnalyzerContext(Language language, String filename, String code, List<AnalyzerRule> rules, AnalysisOptions analysisOptions) {
         super(language, filename, code, rules, analysisOptions);
-        PythonLexer lexer = new PythonLexer(CharStreams.fromString(code));
-        CommonTokenStream tokens = new CommonTokenStream(lexer);
-        PythonParser parser = new PythonParser(tokens);
+        
+        io.codiga.parser.treesitter.python.CodigaVisitor codigaVisitor = new io.codiga.parser.treesitter.python.CodigaVisitor(code);
+        codigaVisitor.parse();
+        entityCheckedToAstElements.get(EntityChecked.ASSIGNMENT).addAll(codigaVisitor.assignments);
+        entityCheckedToAstElements.get(EntityChecked.FOR_LOOP).addAll(codigaVisitor.forStatements);
+        entityCheckedToAstElements.get(EntityChecked.FUNCTION_CALL).addAll(codigaVisitor.functionCalls);
+        entityCheckedToAstElements.get(EntityChecked.FUNCTION_DEFINITION).addAll(codigaVisitor.functionDefinitions);
+        entityCheckedToAstElements.get(EntityChecked.IF_STATEMENT).addAll(codigaVisitor.ifStatements);
+        entityCheckedToAstElements.get(EntityChecked.IMPORT_STATEMENT).addAll(codigaVisitor.fromStatements);
+        entityCheckedToAstElements.get(EntityChecked.IMPORT_STATEMENT).addAll(codigaVisitor.importStatements);
+        entityCheckedToAstElements.get(EntityChecked.TRY_BLOCK).addAll(codigaVisitor.tryStatements);
+        entityCheckedToAstElements.get(EntityChecked.CLASS_DEFINITION).addAll(codigaVisitor.classDefinitions);
 
-        parser.setBuildParseTree(true);
-
-        if (analysisOptions.isUseTreeSitter()) {
-            io.codiga.parser.treesitter.python.CodigaVisitor codigaVisitor = new io.codiga.parser.treesitter.python.CodigaVisitor(code);
-            codigaVisitor.parse();
-            entityCheckedToAstElements.get(EntityChecked.ASSIGNMENT).addAll(codigaVisitor.assignments);
-            entityCheckedToAstElements.get(EntityChecked.FOR_LOOP).addAll(codigaVisitor.forStatements);
-            entityCheckedToAstElements.get(EntityChecked.FUNCTION_CALL).addAll(codigaVisitor.functionCalls);
-            entityCheckedToAstElements.get(EntityChecked.FUNCTION_DEFINITION).addAll(codigaVisitor.functionDefinitions);
-            entityCheckedToAstElements.get(EntityChecked.IF_STATEMENT).addAll(codigaVisitor.ifStatements);
-            entityCheckedToAstElements.get(EntityChecked.IMPORT_STATEMENT).addAll(codigaVisitor.fromStatements);
-            entityCheckedToAstElements.get(EntityChecked.IMPORT_STATEMENT).addAll(codigaVisitor.importStatements);
-            entityCheckedToAstElements.get(EntityChecked.TRY_BLOCK).addAll(codigaVisitor.tryStatements);
-            entityCheckedToAstElements.get(EntityChecked.CLASS_DEFINITION).addAll(codigaVisitor.classDefinitions);
-
-            // Add all entities to the ANY type
-            addAllEntityToAny();
-            // Add additional entities to the ANY type
-            this.entityCheckedToAstElements.get(EntityChecked.ANY).addAll(codigaVisitor.assertStatements);
-        } else {
-            io.codiga.parser.antlr.python.CodigaVisitor codigaVisitor = new io.codiga.parser.antlr.python.CodigaVisitor(code);
-            codigaVisitor.visit(parser.root());
-            entityCheckedToAstElements.get(EntityChecked.ASSIGNMENT).addAll(codigaVisitor.assignments);
-            entityCheckedToAstElements.get(EntityChecked.FOR_LOOP).addAll(codigaVisitor.forStatements);
-            entityCheckedToAstElements.get(EntityChecked.FUNCTION_CALL).addAll(codigaVisitor.functionCalls);
-            entityCheckedToAstElements.get(EntityChecked.FUNCTION_DEFINITION).addAll(codigaVisitor.functionDefinitions);
-            entityCheckedToAstElements.get(EntityChecked.IF_STATEMENT).addAll(codigaVisitor.ifStatements);
-            entityCheckedToAstElements.get(EntityChecked.IMPORT_STATEMENT).addAll(codigaVisitor.fromStatements);
-            entityCheckedToAstElements.get(EntityChecked.IMPORT_STATEMENT).addAll(codigaVisitor.importStatements);
-            entityCheckedToAstElements.get(EntityChecked.TRY_BLOCK).addAll(codigaVisitor.tryStatements);
-            entityCheckedToAstElements.get(EntityChecked.CLASS_DEFINITION).addAll(codigaVisitor.classDefinitions);
-
-            // Add all entities to the ANY type
-            addAllEntityToAny();
-        }
+        // Add all entities to the ANY type
+        addAllEntityToAny();
+        // Add additional entities to the ANY type
+        this.entityCheckedToAstElements.get(EntityChecked.ANY).addAll(codigaVisitor.assertStatements);
 
     }
 }

--- a/core/src/main/java/io/codiga/analyzer/ast/languages/typescript/TypeScriptAnalyzer.java
+++ b/core/src/main/java/io/codiga/analyzer/ast/languages/typescript/TypeScriptAnalyzer.java
@@ -1,5 +1,7 @@
 package io.codiga.analyzer.ast.languages.typescript;
 
+import static io.codiga.metrics.MetricsName.METRIC_DISTRIBUTION_PARSING_TIME_PER_LANGUAGE;
+
 import datadog.trace.api.Trace;
 import io.codiga.analyzer.AnalysisOptions;
 import io.codiga.analyzer.ast.common.AnalyzerCommon;
@@ -12,12 +14,9 @@ import io.codiga.metrics.MetricsInterface;
 import io.codiga.model.Language;
 import io.codiga.model.ast.common.AstElement;
 import io.codiga.model.error.RuleResult;
+import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.List;
-
-import static io.codiga.metrics.MetricsName.METRIC_DISTRIBUTION_PARSING_TIME_PER_LANGUAGE;
 
 public class TypeScriptAnalyzer extends AnalyzerCommon {
 
@@ -54,13 +53,13 @@ public class TypeScriptAnalyzer extends AnalyzerCommon {
 
         vmContext.initializeRule(rule);
 
-        List<AstElement> astElements = context.getElementsToCheck(rule.entityChecked());
+        List<AstElement> astElements = context.getElementsToCheck(rule.entityChecked);
 
-        addVariablesToElements(astElements, rule.variables());
+        addVariablesToElements(astElements, rule.variables);
 
         // no object to analyze, return directly and do not waste resource allocating a VM
         if (astElements.isEmpty()) {
-            return new RuleResult(rule.name(), List.of(), List.of(), null, null, 0);
+            return new RuleResult(rule.name, List.of(), List.of(), null, null, 0);
         }
 
         vmContext.prepareForExecution(analyzerContext, astElements);
@@ -74,7 +73,7 @@ public class TypeScriptAnalyzer extends AnalyzerCommon {
         vmContext.shutdown();
         long endTimestamp = System.currentTimeMillis();
         long executionTimeMs = endTimestamp - startTimestamp;
-        return new RuleResult(rule.name(), vmContext.getViolations(), List.of(), null, finalOutput, executionTimeMs);
+        return new RuleResult(rule.name, vmContext.getViolations(), List.of(), null, finalOutput, executionTimeMs);
     }
 
 

--- a/core/src/main/java/io/codiga/analyzer/ast/vm/VmContext.java
+++ b/core/src/main/java/io/codiga/analyzer/ast/vm/VmContext.java
@@ -47,8 +47,13 @@ public class VmContext {
             + "  }\n"
             + "}\n",
         """
+            var lines = null;
+            var linesLength = [];
             function getCode(start, end, code) {
-              const lines = code.split("\\n");
+              if (!lines) {
+                lines = code.split("\\n");
+              }
+              
               const startLine = start.line - 1;
               const startCol = start.col - 1;
               const endLine = end.line - 1;
@@ -56,13 +61,19 @@ public class VmContext {
 
               var startChar = 0;
               for (var i = 0 ; i < startLine ; i++) {
+                if(!linesLength[i]) {
+                    linesLength[i] = lines[i].length;
+                }
                 startChar = startChar + lines[i].length + 1;
               }
               startChar = startChar + startCol;
 
               var endChar = 0;
-              for (var i = 0 ; i < startLine ; i++) {
-                endChar = endChar + lines[i].length + 1;
+              for (var i = 0 ; i < endLine ; i++) {
+                if(!linesLength[i]) {
+                    linesLength[i] = lines[i].length;
+                }
+                endChar = endChar + linesLength[i] + 1;
               }
               endChar = endChar + endCol;
 
@@ -208,7 +219,7 @@ public class VmContext {
      */
     public void initializeRule(AnalyzerRule analyzerRule) {
 
-        context.eval("js", analyzerRule.code());
+        context.eval("js", analyzerRule.code);
     }
 
     @Trace(operationName = "VmContext.prepareForExecution")

--- a/core/src/main/java/io/codiga/analyzer/pattern/PatternAnalyzer.java
+++ b/core/src/main/java/io/codiga/analyzer/pattern/PatternAnalyzer.java
@@ -31,7 +31,7 @@ public class PatternAnalyzer extends AnalyzerCommon {
 
         // no pattern to match, return directly
         if (patternObjects.isEmpty()) {
-            return new RuleResult(rule.name(), List.of(), List.of(), null, null, 0);
+            return new RuleResult(rule.name, List.of(), List.of(), null, null, 0);
         }
 
         VmContext vmContext = new VmContext(analyzerContext);
@@ -47,7 +47,7 @@ public class PatternAnalyzer extends AnalyzerCommon {
 
         long endTimestamp = System.currentTimeMillis();
         long executionTimeMs = endTimestamp - startTimestamp;
-        return new RuleResult(rule.name(), vmContext.getViolations(), List.of(), null, output, executionTimeMs);
+        return new RuleResult(rule.name, vmContext.getViolations(), List.of(), null, output, executionTimeMs);
     }
 
 

--- a/core/src/main/java/io/codiga/analyzer/pattern/PatternMatcher.java
+++ b/core/src/main/java/io/codiga/analyzer/pattern/PatternMatcher.java
@@ -6,15 +6,14 @@ import io.codiga.model.pattern.PatternObject;
 import io.codiga.model.pattern.PatternVariable;
 import io.codiga.model.pattern.PatternVariableValue;
 import io.codiga.utils.PositionFinder;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class PatternMatcher {
 
@@ -96,7 +95,7 @@ public class PatternMatcher {
             }
         }).toList();
 
-        String regularExpression = prepareStringForRegularExpression(this.analyzerRule.regex());
+        String regularExpression = prepareStringForRegularExpression(this.analyzerRule.regex);
         for (PatternVariable patternVariable : orderedPatternVariables) {
             regularExpression = regularExpression.substring(0, patternVariable.start()) + "(.+)" + regularExpression.substring(patternVariable.end());
         }
@@ -113,7 +112,7 @@ public class PatternMatcher {
      */
     public List<PatternObject> getPatternObjects() {
         List<PatternObject> patternObjects = new ArrayList<>();
-        List<PatternVariable> patternVariables = this.getVariablesFromPattern(analyzerRule.regex());
+        List<PatternVariable> patternVariables = this.getVariablesFromPattern(analyzerRule.regex);
         String regularExpression = this.getRegularExpression(patternVariables);
 
 //        logger.info(String.format("regular expression: %s", regularExpression));

--- a/core/src/main/java/io/codiga/analyzer/rule/AnalyzerRule.java
+++ b/core/src/main/java/io/codiga/analyzer/rule/AnalyzerRule.java
@@ -1,22 +1,66 @@
 package io.codiga.analyzer.rule;
 
+import static io.codiga.utils.TreeSitterUtils.languageToTreeSitterLanguage;
+
+import ai.serenade.treesitter.query.Query;
+import ai.serenade.treesitter.query.exceptions.QueryException;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.codiga.model.EntityChecked;
 import io.codiga.model.Language;
 import io.codiga.model.RuleType;
 import java.util.Map;
+import java.util.Optional;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.ToString;
+import lombok.extern.jackson.Jacksonized;
 
-public record AnalyzerRule(String name,
-                           String description,
-                           Language language,
-                           RuleType type,
-                           @JsonProperty("entity_checked")
-                           EntityChecked entityChecked, // defined/used only when ruleType is an AST rule
-                           String code, // JavaScript code of the rule
-                           String regex, // only defined when using a pattern
-                           @JsonProperty("tree_sitter_query")
-                           String treeSitterQuery, // the tree-sitter query when we are using pattern matching
-                           Map<String, String> variables) {
+@Builder
+@AllArgsConstructor
+@Jacksonized
+@ToString
+public class AnalyzerRule {
+
+    public String name;
+    public String description;
+    public Language language;
+    public RuleType type;
+    @JsonProperty("entity_checked")
+    public EntityChecked entityChecked; // defined/used only when ruleType is an AST rule
+    public String code; // JavaScript code of the rule
+    public String regex; // only defined when using a pattern
+    @JsonProperty("tree_sitter_query")
+    public String treeSitterQuery; // the tree-sitter query when we are using pattern matching
+    public Map<String, String> variables;
+
+    @Builder.Default
+    @JsonIgnore
+    @ToString.Exclude
+    private Query treeSitterQueryObject = null;
+
+    protected void finalize() {
+        if(treeSitterQueryObject!= null) {
+            treeSitterQueryObject.close();
+        }
+    }
+
+    public Query getTreeSitterQueryObject() {
+        if(treeSitterQueryObject != null) {
+            return treeSitterQueryObject;
+        }
+        Optional<Long> treeSitterLanguage = languageToTreeSitterLanguage(language);
+        if(treeSitterLanguage.isPresent()) {
+            try {
+                treeSitterQueryObject = new Query(treeSitterLanguage.get(), this.treeSitterQuery);
+                return treeSitterQueryObject;
+            } catch (QueryException queryObject) {
+                return null;
+            }
+        }
+        return null;
+    }
+
     /**
      * Indicate is a rule is valid for a given language (or not)
      *

--- a/core/src/main/java/io/codiga/analyzer/treesitterpm/TreeSitterPatternAnalyzerContext.java
+++ b/core/src/main/java/io/codiga/analyzer/treesitterpm/TreeSitterPatternAnalyzerContext.java
@@ -10,7 +10,6 @@ import io.codiga.analyzer.ast.common.AnalyzerContext;
 import io.codiga.analyzer.rule.AnalyzerRule;
 import io.codiga.model.Language;
 import java.io.UnsupportedEncodingException;
-import java.lang.ref.Cleaner;
 import java.util.List;
 import java.util.Optional;
 import lombok.Getter;
@@ -26,12 +25,14 @@ public class TreeSitterPatternAnalyzerContext extends AnalyzerContext {
     @Getter
     private Optional<Tree> tree = Optional.empty();
 
+    @Getter
+    private String inlineCode;
+
     private final Logger logger = LoggerFactory.getLogger(TreeSitterPatternAnalyzerContext.class);
 
-    private static final Cleaner CLEANER = Cleaner.create();
 
     @Override
-    public void finalize() {
+    protected void finalize() {
         this.tree.ifPresent(ResourceWithPointer::close);
     }
 

--- a/core/src/main/java/io/codiga/analyzer/treesitterpm/TreeSitterPatternAnalyzerContext.java
+++ b/core/src/main/java/io/codiga/analyzer/treesitterpm/TreeSitterPatternAnalyzerContext.java
@@ -1,0 +1,59 @@
+package io.codiga.analyzer.treesitterpm;
+
+import static io.codiga.utils.TreeSitterUtils.languageToTreeSitterLanguage;
+
+import ai.serenade.treesitter.Parser;
+import ai.serenade.treesitter.Tree;
+import ai.serenade.treesitter.query.internals.ResourceWithPointer;
+import io.codiga.analyzer.AnalysisOptions;
+import io.codiga.analyzer.ast.common.AnalyzerContext;
+import io.codiga.analyzer.rule.AnalyzerRule;
+import io.codiga.model.Language;
+import java.io.UnsupportedEncodingException;
+import java.lang.ref.Cleaner;
+import java.util.List;
+import java.util.Optional;
+import lombok.Getter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * An analyzer context that contains the tree-sitter tree to analyze.
+ * It is created once and for all before we do the analysis.
+ */
+public class TreeSitterPatternAnalyzerContext extends AnalyzerContext {
+
+    @Getter
+    private Optional<Tree> tree = Optional.empty();
+
+    private final Logger logger = LoggerFactory.getLogger(TreeSitterPatternAnalyzerContext.class);
+
+    private static final Cleaner CLEANER = Cleaner.create();
+
+    @Override
+    public void finalize() {
+        this.tree.ifPresent(ResourceWithPointer::close);
+    }
+
+    public TreeSitterPatternAnalyzerContext(Language language, String filename, String code, List<AnalyzerRule> rules, AnalysisOptions analysisOptions) {
+        super(language, filename, code, rules, analysisOptions);
+
+        Optional<Long> treeSitterLanguage = languageToTreeSitterLanguage(language);
+        if(treeSitterLanguage.isPresent()) {
+            try (Parser parser = new Parser()) {
+                parser.setLanguage(treeSitterLanguage.get());
+                try {
+                    Tree tsTree = parser.parseString(code);
+                    this.tree = Optional.ofNullable(tsTree);
+                }
+                catch (UnsupportedEncodingException exception) {
+                    this.tree = Optional.empty();
+                }
+            }
+        }
+
+    }
+
+}
+
+

--- a/core/src/main/java/io/codiga/analyzer/treesitterpm/TreeSitterPatternMatching.java
+++ b/core/src/main/java/io/codiga/analyzer/treesitterpm/TreeSitterPatternMatching.java
@@ -5,8 +5,6 @@ import static io.codiga.utils.TreeSitterUtils.getTreeFromNode;
 import static io.codiga.utils.TreeSitterUtils.languageToTreeSitterLanguage;
 
 import ai.serenade.treesitter.Node;
-import ai.serenade.treesitter.Parser;
-import ai.serenade.treesitter.Tree;
 import ai.serenade.treesitter.query.Query;
 import ai.serenade.treesitter.query.QueryCapture;
 import ai.serenade.treesitter.query.QueryCursor;
@@ -28,7 +26,6 @@ import io.codiga.model.ast.common.TreeSitterAstElement;
 import io.codiga.model.context.Context;
 import io.codiga.model.error.RuleResult;
 import io.codiga.model.tree_sitter.TsPatternMatch;
-import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -39,99 +36,108 @@ import org.slf4j.LoggerFactory;
 
 public class TreeSitterPatternMatching extends AnalyzerCommon {
 
-    private final AnalyzerFuturePool pool = AnalyzerFuturePool.getInstance();
+  private final AnalyzerFuturePool pool = AnalyzerFuturePool.getInstance();
 
-    private final Logger logger = LoggerFactory.getLogger(TreeSitterPatternMatching.class);
+  private final Logger logger = LoggerFactory.getLogger(TreeSitterPatternMatching.class);
 
-    public TreeSitterPatternMatching(MetricsInterface metrics, ErrorReportingInterface errorReporting, AnalyzerConfiguration configuration) {
-        super(metrics, errorReporting, configuration);
+  public TreeSitterPatternMatching(
+      MetricsInterface metrics,
+      ErrorReportingInterface errorReporting,
+      AnalyzerConfiguration configuration) {
+    super(metrics, errorReporting, configuration);
+  }
+
+  @Trace(operationName = "TreeSitterPatternMatching.execute")
+  @Override
+  public RuleResult execute(AnalyzerContext analyzerContext, AnalyzerRule rule) {
+
+    TreeSitterPatternAnalyzerContext treeSitterPatternAnalyzerContext =
+        (TreeSitterPatternAnalyzerContext) analyzerContext;
+
+    long startTimestamp = System.currentTimeMillis();
+    Context ruleContext =
+        new io.codiga.model.context.Context(
+            treeSitterPatternAnalyzerContext.getCode(), rule.variables());
+
+    Optional<String> error = Optional.empty(); // put the error if any
+    Optional<Long> treeSitterLanguage = languageToTreeSitterLanguage(rule.language());
+
+    // Language is not supported
+    if (treeSitterLanguage.isEmpty()) {
+      return new RuleResult(rule.name(), List.of(), List.of(), null, null, 0);
     }
 
-    @Trace(operationName = "TreeSitterPatternMatching.execute")
-    @Override
-    public RuleResult execute(AnalyzerContext analyzerContext, AnalyzerRule rule) {
-        long startTimestamp = System.currentTimeMillis();
-        Context ruleContext = new io.codiga.model.context.Context(analyzerContext.getCode(), rule.variables());
+    VmContext vmContext = new VmContext(treeSitterPatternAnalyzerContext);
+    vmContext.initializeRule(rule);
 
-        Optional<String> error = Optional.empty(); // put the error if any
-        Optional<Long> treeSitterLanguage = languageToTreeSitterLanguage(rule.language());
+    if (treeSitterPatternAnalyzerContext.getTree().isPresent()) {
+      try (Query query = new Query(treeSitterLanguage.get(), rule.treeSitterQuery())) {
+        List<QueryCapture> captures = query.getCaptures();
+        try (QueryCursor queryCursor =
+            query.execute(treeSitterPatternAnalyzerContext.getTree().get().getRootNode())) {
+          QueryMatch queryMatch = queryCursor.nextMatch();
+          List<TsPatternMatch> matches = new ArrayList<>();
 
-        // Language is not supported
-        if (treeSitterLanguage.isEmpty()) {
-            return new RuleResult(rule.name(), List.of(), List.of(), null, null, 0);
-        }
-
-        VmContext vmContext = new VmContext(analyzerContext);
-        vmContext.initializeRule(rule);
-
-        try (Parser parser = new Parser()) {
-            parser.setLanguage(treeSitterLanguage.get());
-            try (Tree tree = parser.parseString(analyzerContext.getCode())) {
-                try (Query query = new Query(treeSitterLanguage.get(), rule.treeSitterQuery())) {
-                    List<QueryCapture> captures = query.getCaptures();
-                    try (QueryCursor queryCursor = query.execute(tree.getRootNode())) {
-                        QueryMatch queryMatch = queryCursor.nextMatch();
-                        List<TsPatternMatch> matches = new ArrayList<>();
-
-                        /**
-                         * For each match - build an object that contains each match for each capture - add the
-                         * match to the list of matches
-                         */
-                        while (queryMatch != null) {
-                            Map<String, TreeSitterAstElement> match = new HashMap<>();
-                            Map<String, List<TreeSitterAstElement>> matchesList = new HashMap<>();
-                            for (QueryMatchCapture queryMatchCapture : queryMatch.getCaptures()) {
-                                int idx = queryMatchCapture.index;
-                                String name = captures.get(idx).getName();
-                                Node node = queryMatchCapture.node;
-                                Optional<TreeSitterAstElement> astElementOptional = getTreeFromNode(node);
-                                if (astElementOptional.isPresent()) {
-                                    match.put(name, astElementOptional.get());
-                                    if(!matchesList.containsKey(name)) {
-                                        matchesList.put(name, new ArrayList<>());
-                                    }
-                                    matchesList.get(name).add(astElementOptional.get());
-                                }
-
-                            }
-                            matches.add(new TsPatternMatch(match, matchesList, ruleContext));
-                            queryMatch = queryCursor.nextMatch();
-                        }
-
-                        /**
-                         * We have the list of matches in the variable matches. Invoke the JavaScript rule on
-                         * all these matches.
-                         */
-                        vmContext.prepareForExecution(analyzerContext, matches);
-                        vmContext.execute(rule);
-                    }
-
-                } catch (QueryException e) {
-                    error = Optional.of(ERROR_RULE_INVALID_QUERY);
+          /**
+           * For each match - build an object that contains each match for each capture - add the
+           * match to the list of matches
+           */
+          while (queryMatch != null) {
+            Map<String, TreeSitterAstElement> match = new HashMap<>();
+            Map<String, List<TreeSitterAstElement>> matchesList = new HashMap<>();
+            for (QueryMatchCapture queryMatchCapture : queryMatch.getCaptures()) {
+              int idx = queryMatchCapture.index;
+              String name = captures.get(idx).getName();
+              Node node = queryMatchCapture.node;
+              Optional<TreeSitterAstElement> astElementOptional = getTreeFromNode(node);
+              if (astElementOptional.isPresent()) {
+                match.put(name, astElementOptional.get());
+                if (!matchesList.containsKey(name)) {
+                  matchesList.put(name, new ArrayList<>());
                 }
-            } catch (UnsupportedEncodingException e) {
-                logger.info("error when decoding the code");
+                matchesList.get(name).add(astElementOptional.get());
+              }
             }
+            matches.add(new TsPatternMatch(match, matchesList, ruleContext));
+            queryMatch = queryCursor.nextMatch();
+          }
+
+          /**
+           * We have the list of matches in the variable matches. Invoke the JavaScript rule on all
+           * these matches.
+           */
+          vmContext.prepareForExecution(analyzerContext, matches);
+          vmContext.execute(rule);
         }
 
-        String output = vmContext.getOutput();
-        vmContext.shutdown();
-
-        long endTimestamp = System.currentTimeMillis();
-        long executionTimeMs = endTimestamp - startTimestamp;
-
-        // if there is an error, we return an rule with the error and no violation
-        if (error.isPresent()) {
-            return new RuleResult(rule.name(), List.of(), error.stream().toList(), null, output, executionTimeMs);
-        }
-        return new RuleResult(rule.name(), vmContext.getViolations(), List.of(), null, output, executionTimeMs);
+      } catch (QueryException e) {
+        error = Optional.of(ERROR_RULE_INVALID_QUERY);
+      }
     }
 
+    String output = vmContext.getOutput();
+    vmContext.shutdown();
 
-    @Trace(operationName = "TreeSitterPatternMatching.buildContext")
-    @Override
-    public AnalyzerContext buildContext(Language language, String filename, String code, List<AnalyzerRule> rules, AnalysisOptions options) {
-        return new AnalyzerContext(language, filename, code, rules, options);
+    long endTimestamp = System.currentTimeMillis();
+    long executionTimeMs = endTimestamp - startTimestamp;
+
+    // if there is an error, we return an rule with the error and no violation
+    if (error.isPresent()) {
+      return new RuleResult(
+          rule.name(), List.of(), error.stream().toList(), null, output, executionTimeMs);
     }
+    return new RuleResult(
+        rule.name(), vmContext.getViolations(), List.of(), null, output, executionTimeMs);
+  }
 
+  @Trace(operationName = "TreeSitterPatternMatching.buildContext")
+  @Override
+  public AnalyzerContext buildContext(
+      Language language,
+      String filename,
+      String code,
+      List<AnalyzerRule> rules,
+      AnalysisOptions options) {
+    return new TreeSitterPatternAnalyzerContext(language, filename, code, rules, options);
+  }
 }

--- a/core/src/main/java/io/codiga/warmup/AnalyzerWarmup.java
+++ b/core/src/main/java/io/codiga/warmup/AnalyzerWarmup.java
@@ -1,18 +1,17 @@
 package io.codiga.warmup;
 
+import static io.codiga.warmup.AnalyzerWarmupCode.WARMUP_CODE;
+
 import io.codiga.analyzer.AnalysisOptions;
 import io.codiga.analyzer.Analyzer;
 import io.codiga.analyzer.rule.AnalyzerRule;
 import io.codiga.model.error.AnalysisResult;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.util.Base64;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
-
-import static io.codiga.warmup.AnalyzerWarmupCode.WARMUP_CODE;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class AnalyzerWarmup {
 
@@ -41,13 +40,16 @@ public class AnalyzerWarmup {
                                     .analyzerRuleList
                                     .stream()
                                     .map(analyzerRule ->
-                                            new AnalyzerRule(
-                                                    analyzerRule.name(),
-                                                    analyzerRule.description(),
-                                                    analyzerRule.language(),
-                                                    analyzerRule.type(),
-                                                    analyzerRule.entityChecked(),
-                                                    new String(Base64.getDecoder().decode(analyzerRule.code())), analyzerRule.regex(), null, analyzerRule.variables())
+                                        AnalyzerRule.builder()
+                                            .name(analyzerRule.name)
+                                            .description(analyzerRule.description)
+                                            .language(analyzerRule.language)
+                                            .type(analyzerRule.type)
+                                            .entityChecked(analyzerRule.entityChecked)
+                                            .code(new String(Base64.getDecoder().decode(analyzerRule.code)))
+                                            .regex(analyzerRule.regex)
+                                            .variables(analyzerRule.variables)
+                                            .build()
                                     ).collect(Collectors.toList()),
                             options);
                     AnalysisResult analysisResult = futureResult.join();

--- a/core/src/main/java/io/codiga/warmup/AnalyzerWarmupCode.java
+++ b/core/src/main/java/io/codiga/warmup/AnalyzerWarmupCode.java
@@ -4,79 +4,86 @@ import io.codiga.analyzer.rule.AnalyzerRule;
 import io.codiga.model.EntityChecked;
 import io.codiga.model.Language;
 import io.codiga.model.RuleType;
-
 import java.util.List;
 
 public class AnalyzerWarmupCode {
 
-    public final static List<AnalyzerWarmupCodeData> WARMUP_CODE = List.of(
-        new AnalyzerWarmupCodeDataBuilder()
-            .setFilename("pythoncode.py")
-            .setCode("YSA9IDEKYiA9IDIKcmFpc2UgTm90SW1wbGVtZW50ZWQKYyA9IDM=")
-            .setLanguage(Language.PYTHON)
-            .setAnalyzerRuleList(
-                List.of(new AnalyzerRule(
-                    "raising-not-implemented",
-                    "raising-not-implemented description",
-                    Language.PYTHON,
-                    RuleType.REGEX,
-                    null,
-                    "ZnVuY3Rpb24gdmlzaXQocGF0dGVybiwgZmlsZW5hbWUsIGNvZGUpIHsKICBjb25zdCBleGNlcHRpb25OYW1lID0gcGF0dGVybi52YXJpYWJsZXMuZ2V0KCJleGNlcHRpb25OYW1lIik7CiAgaWYgKGV4Y2VwdGlvbk5hbWUgJiYgZXhjZXB0aW9uTmFtZS52YWx1ZSA9PT0gIk5vdEltcGxlbWVudGVkIikgewogICAgY29uc3QgZXJyb3IgPSBidWlsZEVycm9yKHBhdHRlcm4uc3RhcnQubGluZSwgcGF0dGVybi5zdGFydC5jb2wsIHBhdHRlcm4uZW5kLmxpbmUsIHBhdHRlcm4uZW5kLmNvbCwgInJhaXNlIE5vdEltcGxlbWVudGVkIGlzIG5vdCBhIHZhbGlkIGVycm9yIiwgIklORk8iLCAiQkVTVF9QUkFDVElDRVMiKTsKICAgIGNvbnN0IGVkaXQgPSBidWlsZEVkaXQocGF0dGVybi5zdGFydC5saW5lLCBwYXR0ZXJuLnN0YXJ0LmNvbCwgcGF0dGVybi5lbmQubGluZSwgcGF0dGVybi5lbmQuY29sLCAidXBkYXRlIiwgInJhaXNlIE5vdEltcGxlbWVudGVkRXJyb3IiKTsKICAgIGNvbnN0IGZpeCA9IGJ1aWxkRml4KCJyYWlzZSBOb3RJbXBsZW1lbnRlZEVycm9yIiwgW2VkaXRdKTsKICAgIGFkZEVycm9yKGVycm9yLmFkZEZpeChmaXgpKTsKICB9Cn0=",
-                    "raise ${exceptionName}",
-                    null,
-                        null
-                ))
-            ).createAnalyzerWarmupCodeData(),
-        new AnalyzerWarmupCodeDataBuilder()
-            .setFilename("pythoncode.py")
-            .setCode("cHJpbnQoImJsYSIpCmV2YWwoJ1sxLCAyLCAzXScp")
-            .setLanguage(Language.PYTHON)
-            .setAnalyzerRuleList(
-                List.of(new AnalyzerRule(
-                    "no-eval",
-                    "no-eval description",
-                    Language.PYTHON,
-                    RuleType.AST_CHECK,
-                    EntityChecked.FUNCTION_CALL,
-                    "ZnVuY3Rpb24gdmlzaXQobm9kZSkgewogIGlmKG5vZGUuZnVuY3Rpb25OYW1lLnZhbHVlID09PSAiZXZhbCIpewogICAgY29uc3QgaGFzT25lQXJndW1lbnQgPSBub2RlLmFyZ3VtZW50cy52YWx1ZXMgJiYgbm9kZS5hcmd1bWVudHMudmFsdWVzLmxlbmd0aCA9PT0gMTsKCiAgICBjb25zdCBlcnJvciA9IGJ1aWxkRXJyb3Iobm9kZS5zdGFydC5saW5lLCBub2RlLnN0YXJ0LmNvbCwgbm9kZS5lbmQubGluZSwgbm9kZS5lbmQuY29sLCAiZG8gbm90IHVzZSBldmFsIGFzIHRoaXMgaXMgdW5zYWZlIiwgIkNSSVRJQ0FMIiwgIlNBRkVUWSIpOwoKICAgIGNvbnN0IGFyZ3VtZW50VmFsdWUgPSBub2RlLmFyZ3VtZW50cy52YWx1ZXNbMF0udmFsdWUuc3RyOwogICAgY29uc3QgbmV3RnVuY3Rpb25DYWxsID0gYGxpdGVyYWxfZXZhbCgke2FyZ3VtZW50VmFsdWV9KWA7CiAgICBjb25zdCBlZGl0UmVwbGFjZUZ1bmN0aW9uQ2FsbCA9IGJ1aWxkRWRpdFVwZGF0ZShub2RlLnN0YXJ0LmxpbmUsIG5vZGUuc3RhcnQuY29sLCBub2RlLmVuZC5saW5lLCBub2RlLmVuZC5jb2wsIG5ld0Z1bmN0aW9uQ2FsbCkKCiAgICBjb25zdCBlZGl0QWRkSW1wb3J0ID0gYnVpbGRFZGl0QWRkKDEsIDEsICJmcm9tIGFzdCBpbXBvcnQgbGl0ZXJhbF9ldmFsXG4iKTsKCgogICAgY29uc3QgZml4ID0gYnVpbGRGaXgoInJlcGxhY2Ugd2l0aCBsaXRlcmFsX2V2YWwiLCBbZWRpdFJlcGxhY2VGdW5jdGlvbkNhbGwsIGVkaXRBZGRJbXBvcnRdKTsKICAgIGFkZEVycm9yKGVycm9yLmFkZEZpeChmaXgpKTsKICB9Cn0=",
-                    null,
-                    null,
-                        null
-                ))
-            ).createAnalyzerWarmupCodeData(),
-        new AnalyzerWarmupCodeDataBuilder()
-            .setFilename("pythoncode.py")
-            .setCode("aW1wb3J0IHJlcXVlc3RzCnIgPSByZXF1ZXN0cy5nZXQodywgdmVyaWZ5PUZhbHNlKQpyID0gcmVxdWVzdHMuZ2V0KHcsIHZlcmlmeT1GYWxzZSwgdGltZW91dD0xMCk=")
-            .setLanguage(Language.PYTHON)
-            .setAnalyzerRuleList(
-                List.of(new AnalyzerRule(
-                    "no-timeout",
-                    "no-timeout description",
-                    Language.PYTHON,
-                    RuleType.AST_CHECK,
-                    EntityChecked.FUNCTION_CALL,
-                    "ZnVuY3Rpb24gdmlzaXQobm9kZSkgewogIGNvbnN0IGhhc1RpbWVvdXQgPSBub2RlLmFyZ3VtZW50cy52YWx1ZXMuZmlsdGVyKGEgPT4gYS5uYW1lICYmIGEubmFtZS52YWx1ZSA9PSAidGltZW91dCIpLmxlbmd0aCA+IDA7CiAgY29uc3QgYXJndW1lbnRzID0gbm9kZS5hcmd1bWVudHMudmFsdWVzOwogIGNvbnN0IG5iQXJndW1lbnRzID0gbm9kZS5hcmd1bWVudHMudmFsdWVzLmxlbmd0aDsKICBjb25zdCBhbGxQYWNrYWdlcyA9IG5vZGUuY29udGV4dC5pbXBvcnRzLmZpbHRlcihpID0+IGkucGFja2FnZXMpLmZsYXRNYXAoaSA9PiBpLnBhY2thZ2VzLm1hcChwID0+IHAubmFtZS5zdHIpKTsKICBjb25zdCB1c2VSZXF1ZXN0c1BhY2thZ2UgPSBhbGxQYWNrYWdlcy5maWx0ZXIoaSA9PiBpID09PSAicmVxdWVzdHMiKS5sZW5ndGggPiAwOwogIGlmKCFoYXNUaW1lb3V0ICYmIHVzZVJlcXVlc3RzUGFja2FnZSAmJiBub2RlLmZ1bmN0aW9uTmFtZS52YWx1ZSA9PT0gImdldCIgJiYgbm9kZS5tb2R1bGVPck9iamVjdC52YWx1ZSA9PT0gInJlcXVlc3RzIil7CiAgICBjb25zdCBlcnJvciA9IGJ1aWxkRXJyb3Iobm9kZS5zdGFydC5saW5lLCBub2RlLnN0YXJ0LmNvbCwgbm9kZS5lbmQubGluZSwgbm9kZS5lbmQuY29sLCAidGltZW91dCBub3QgZGVmaW5lZCIsICJDUklUSUNBTCIsICJTQUZFVFkiKTsKICAgIGNvbnN0IGxpbmVUb0luc2VydCA9IGFyZ3VtZW50c1thcmd1bWVudHMubGVuZ3RoIC0gMV0uZW5kLmxpbmU7CiAgICBjb25zdCBjb2xUb0luc2VydCA9IGFyZ3VtZW50c1thcmd1bWVudHMubGVuZ3RoIC0gMV0uZW5kLmNvbDsKICAgIGNvbnN0IGVkaXQgPSBidWlsZEVkaXRBZGQobGluZVRvSW5zZXJ0LCBjb2xUb0luc2VydCwgIiwgdGltZW91dD01IikKICAgIGNvbnN0IGZpeCA9IGJ1aWxkRml4KCJhZGQgdGltZW91dCBhcmd1bWVudCIsIFtlZGl0XSk7CiAgICBhZGRFcnJvcihlcnJvci5hZGRGaXgoZml4KSk7CiAgfQp9",
-                    null,
-                    null,
-                        null
-                ))
-            ).createAnalyzerWarmupCodeData(),
-        new AnalyzerWarmupCodeDataBuilder()
-            .setFilename("pythoncode.py")
-            .setCode("aW1wb3J0IHN1YnByb2Nlc3MKc3VicHJvY2Vzcy5Qb3BlbignL2Jpbi9scyAlcycgJSAoJ3NvbWV0aGluZycsKSwgc2hlbGw9VHJ1ZSk=")
-            .setLanguage(Language.PYTHON)
-            .setAnalyzerRuleList(
-                List.of(new AnalyzerRule(
-                    "subprocess-shell-true",
-                    "subprocess-shell-true description",
-                    Language.PYTHON,
-                    RuleType.AST_CHECK,
-                    EntityChecked.FUNCTION_CALL,
-                    "ZnVuY3Rpb24gdmlzaXQobm9kZSwgZmlsZW5hbWUsIGNvZGUpIHsKICBpZiAoIW5vZGUuYXJndW1lbnRzIHx8ICFub2RlLmNvbnRleHQgfHwgIW5vZGUuYXJndW1lbnRzLnZhbHVlcyB8fCAhbm9kZS5mdW5jdGlvbk5hbWUpewogICAgcmV0dXJuOwogIH0KICAKICBjb25zdCBmdW5jdGlvbnMgPSBbIlBvcGVuIiwgInJ1biIsICJjYWxsIl07CiAgCiAgaWYgKCFmdW5jdGlvbnMuaW5jbHVkZXMobm9kZS5mdW5jdGlvbk5hbWUudmFsdWUpKSB7CiAgICByZXR1cm47CiAgfQogIAogIGZ1bmN0aW9ucy5mb3JFYWNoKGZ1bmN0aW9uTmFtZSA9PiB7CiAgICBjb25zdCBoYXNTaGVsbFRydWUgPSBub2RlLmFyZ3VtZW50cy52YWx1ZXMuZmlsdGVyKGEgPT4gYS5uYW1lICYmIGEubmFtZS52YWx1ZSA9PSAic2hlbGwiICYmIGEudmFsdWUgJiYgYS52YWx1ZS52YWx1ZSA9PSAiVHJ1ZSIpLmxlbmd0aCA+IDA7CiAgICBjb25zdCBhbGxQYWNrYWdlcyA9IG5vZGUuY29udGV4dC5pbXBvcnRzLmZpbHRlcihpID0+IGkucGFja2FnZXMpLmZsYXRNYXAoaSA9PiBpLnBhY2thZ2VzLm1hcChwID0+IHAubmFtZS5zdHIpKTsKICAgIGNvbnN0IHVzZVN1YnByb2Nlc3NQYWNrYWdlID0gYWxsUGFja2FnZXMuZmlsdGVyKGkgPT4gaSA9PT0gInN1YnByb2Nlc3MiKS5sZW5ndGggPiAwOwogICAgY29uc3QgaW1wb3J0RnJvbSA9IG5vZGUuY29udGV4dC5pbXBvcnRzCiAgICAgICAgLmZpbHRlcihyID0+IHIucGtnICYmIHIucGtnLnZhbHVlID09PSAic3VicHJvY2VzcyIgJiYgci5lbGVtZW50cyAmJiByLmVsZW1lbnRzLmZpbHRlcihlID0+IGUubmFtZSkubWFwKGUgPT4gZS5uYW1lLnZhbHVlKS5pbmNsdWRlcyhmdW5jdGlvbk5hbWUpKTsKICAgIGNvbnN0IHVzZUltcG9ydEZyb20gPSBpbXBvcnRGcm9tLmxlbmd0aCA+IDA7CiAgICBpZigoaGFzU2hlbGxUcnVlICYmIHVzZVN1YnByb2Nlc3NQYWNrYWdlICYmIG5vZGUuZnVuY3Rpb25OYW1lLnZhbHVlID09PSBmdW5jdGlvbk5hbWUgJiYgbm9kZS5tb2R1bGVPck9iamVjdC52YWx1ZSA9PT0gInN1YnByb2Nlc3MiKXx8CiAgICAgICAodXNlSW1wb3J0RnJvbSAmJiBub2RlLmZ1bmN0aW9uTmFtZS52YWx1ZSA9PT0gZnVuY3Rpb25OYW1lKSl7CiAgICAgIAogICAgICAKICAgICAgZm9yICh2YXIgaSA9IDAgOyBpIDwgbm9kZS5hcmd1bWVudHMudmFsdWVzLmxlbmd0aCA7IGkrKykgewogICAgICAgIGNvbnN0IGFyZyA9IG5vZGUuYXJndW1lbnRzLnZhbHVlc1tpXTsKICAgICAgICBjb25zdCBuYkFyZ3VtZW50cyA9IG5vZGUuYXJndW1lbnRzLnZhbHVlcy5sZW5ndGg7CiAgICAgICAgaWYoYXJnLm5hbWUgJiYgYXJnLm5hbWUudmFsdWUgPT0gInNoZWxsIiAmJiBhcmcudmFsdWUgJiYgYXJnLnZhbHVlLnZhbHVlID09ICJUcnVlIikgewogICAgICAgICAgdmFyIGVycm9yID0gYnVpbGRFcnJvcihub2RlLnN0YXJ0LmxpbmUsIG5vZGUuc3RhcnQuY29sLCBub2RlLmVuZC5saW5lLCBub2RlLmVuZC5jb2wsICJzaGVsbCBkZWZpbmVkIHdpdGggdHJ1ZSIsICJDUklUSUNBTCIsICJTRUNVUklUWSIpOwoKCgkJCQkJaWYoaSA+IDApIHsKICAgICAgICAgICBjb25zdCBwcmV2aW91c0FyZ3VtZW50ID0gbm9kZS5hcmd1bWVudHMudmFsdWVzW2ktMV07CiAgICAgICAgICAgY29uc3QgZWRpdCA9IGJ1aWxkRWRpdFJlbW92ZShwcmV2aW91c0FyZ3VtZW50LmVuZC5saW5lLCBwcmV2aW91c0FyZ3VtZW50LmVuZC5jb2wsCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICBhcmcuZW5kLmxpbmUsIGFyZy5lbmQuY29sKQogICAgCQkJIGNvbnN0IGZpeCA9IGJ1aWxkRml4KCJyZW1vdmUgc2hlbGwgYXJndW1lbnQiLCBbZWRpdF0pOwogICAgICAgICAgIGVycm9yID0gZXJyb3IuYWRkRml4KGZpeCk7CiAgICAgICAgICB9CgogICAgICAgICAgCgkJCQkJIGFkZEVycm9yKGVycm9yKTsKICAgICAgICB9CiAgICAgIH0gICAgICAKICAgIH0KICB9KTsKfQ==",
-                    null,
-                    null,
-                        null
-                ))
-            ).createAnalyzerWarmupCodeData()
-    );
+  public final static List<AnalyzerWarmupCodeData> WARMUP_CODE =
+      List.of(
+          new AnalyzerWarmupCodeDataBuilder()
+              .setFilename("pythoncode.py")
+              .setCode("YSA9IDEKYiA9IDIKcmFpc2UgTm90SW1wbGVtZW50ZWQKYyA9IDM=")
+              .setLanguage(Language.PYTHON)
+              .setAnalyzerRuleList(
+                  List.of(
+                      AnalyzerRule.builder()
+                          .name("raising-not-implemented")
+                          .description("raising-not-implemented description")
+                          .language(Language.PYTHON)
+                          .type(RuleType.REGEX)
+                          .entityChecked(null)
+                          .code("ZnVuY3Rpb24gdmlzaXQocGF0dGVybiwgZmlsZW5hbWUsIGNvZGUpIHsKICBjb25zdCBleGNlcHRpb25OYW1lID0gcGF0dGVybi52YXJpYWJsZXMuZ2V0KCJleGNlcHRpb25OYW1lIik7CiAgaWYgKGV4Y2VwdGlvbk5hbWUgJiYgZXhjZXB0aW9uTmFtZS52YWx1ZSA9PT0gIk5vdEltcGxlbWVudGVkIikgewogICAgY29uc3QgZXJyb3IgPSBidWlsZEVycm9yKHBhdHRlcm4uc3RhcnQubGluZSwgcGF0dGVybi5zdGFydC5jb2wsIHBhdHRlcm4uZW5kLmxpbmUsIHBhdHRlcm4uZW5kLmNvbCwgInJhaXNlIE5vdEltcGxlbWVudGVkIGlzIG5vdCBhIHZhbGlkIGVycm9yIiwgIklORk8iLCAiQkVTVF9QUkFDVElDRVMiKTsKICAgIGNvbnN0IGVkaXQgPSBidWlsZEVkaXQocGF0dGVybi5zdGFydC5saW5lLCBwYXR0ZXJuLnN0YXJ0LmNvbCwgcGF0dGVybi5lbmQubGluZSwgcGF0dGVybi5lbmQuY29sLCAidXBkYXRlIiwgInJhaXNlIE5vdEltcGxlbWVudGVkRXJyb3IiKTsKICAgIGNvbnN0IGZpeCA9IGJ1aWxkRml4KCJyYWlzZSBOb3RJbXBsZW1lbnRlZEVycm9yIiwgW2VkaXRdKTsKICAgIGFkZEVycm9yKGVycm9yLmFkZEZpeChmaXgpKTsKICB9Cn0=")
+                          .regex("raise ${exceptionName}")
+                          .treeSitterQuery(null)
+                          .variables(null)
+                          .build()
+                  ))
+              .createAnalyzerWarmupCodeData(),
+          new AnalyzerWarmupCodeDataBuilder()
+              .setFilename("pythoncode.py")
+              .setCode("cHJpbnQoImJsYSIpCmV2YWwoJ1sxLCAyLCAzXScp")
+              .setLanguage(Language.PYTHON)
+              .setAnalyzerRuleList(
+                  List.of(
+                      AnalyzerRule.builder()
+                          .name("no-eval")
+                          .description("no-eval description")
+                          .language(Language.PYTHON)
+                          .type(RuleType.AST_CHECK)
+                          .entityChecked(EntityChecked.FUNCTION_CALL)
+                          .code("ZnVuY3Rpb24gdmlzaXQobm9kZSkgewogIGlmKG5vZGUuZnVuY3Rpb25OYW1lLnZhbHVlID09PSAiZXZhbCIpewogICAgY29uc3QgaGFzT25lQXJndW1lbnQgPSBub2RlLmFyZ3VtZW50cy52YWx1ZXMgJiYgbm9kZS5hcmd1bWVudHMudmFsdWVzLmxlbmd0aCA9PT0gMTsKCiAgICBjb25zdCBlcnJvciA9IGJ1aWxkRXJyb3Iobm9kZS5zdGFydC5saW5lLCBub2RlLnN0YXJ0LmNvbCwgbm9kZS5lbmQubGluZSwgbm9kZS5lbmQuY29sLCAiZG8gbm90IHVzZSBldmFsIGFzIHRoaXMgaXMgdW5zYWZlIiwgIkNSSVRJQ0FMIiwgIlNBRkVUWSIpOwoKICAgIGNvbnN0IGFyZ3VtZW50VmFsdWUgPSBub2RlLmFyZ3VtZW50cy52YWx1ZXNbMF0udmFsdWUuc3RyOwogICAgY29uc3QgbmV3RnVuY3Rpb25DYWxsID0gYGxpdGVyYWxfZXZhbCgke2FyZ3VtZW50VmFsdWV9KWA7CiAgICBjb25zdCBlZGl0UmVwbGFjZUZ1bmN0aW9uQ2FsbCA9IGJ1aWxkRWRpdFVwZGF0ZShub2RlLnN0YXJ0LmxpbmUsIG5vZGUuc3RhcnQuY29sLCBub2RlLmVuZC5saW5lLCBub2RlLmVuZC5jb2wsIG5ld0Z1bmN0aW9uQ2FsbCkKCiAgICBjb25zdCBlZGl0QWRkSW1wb3J0ID0gYnVpbGRFZGl0QWRkKDEsIDEsICJmcm9tIGFzdCBpbXBvcnQgbGl0ZXJhbF9ldmFsXG4iKTsKCgogICAgY29uc3QgZml4ID0gYnVpbGRGaXgoInJlcGxhY2Ugd2l0aCBsaXRlcmFsX2V2YWwiLCBbZWRpdFJlcGxhY2VGdW5jdGlvbkNhbGwsIGVkaXRBZGRJbXBvcnRdKTsKICAgIGFkZEVycm9yKGVycm9yLmFkZEZpeChmaXgpKTsKICB9Cn0=")
+                          .regex(null)
+                          .treeSitterQuery(null)
+                          .variables(null)
+                          .build()
+                  ))
+              .createAnalyzerWarmupCodeData(),
+          new AnalyzerWarmupCodeDataBuilder()
+              .setFilename("pythoncode.py")
+              .setCode(
+                  "aW1wb3J0IHJlcXVlc3RzCnIgPSByZXF1ZXN0cy5nZXQodywgdmVyaWZ5PUZhbHNlKQpyID0gcmVxdWVzdHMuZ2V0KHcsIHZlcmlmeT1GYWxzZSwgdGltZW91dD0xMCk=")
+              .setLanguage(Language.PYTHON)
+              .setAnalyzerRuleList(
+                  List.of(
+                      AnalyzerRule.builder()
+                          .name("no-timeout")
+                          .description("no-timeout description")
+                          .language(Language.PYTHON)
+                          .type(RuleType.AST_CHECK)
+                          .entityChecked(EntityChecked.FUNCTION_CALL)
+                          .code("ZnVuY3Rpb24gdmlzaXQobm9kZSkgewogIGNvbnN0IGhhc1RpbWVvdXQgPSBub2RlLmFyZ3VtZW50cy52YWx1ZXMuZmlsdGVyKGEgPT4gYS5uYW1lICYmIGEubmFtZS52YWx1ZSA9PSAidGltZW91dCIpLmxlbmd0aCA+IDA7CiAgY29uc3QgYXJndW1lbnRzID0gbm9kZS5hcmd1bWVudHMudmFsdWVzOwogIGNvbnN0IG5iQXJndW1lbnRzID0gbm9kZS5hcmd1bWVudHMudmFsdWVzLmxlbmd0aDsKICBjb25zdCBhbGxQYWNrYWdlcyA9IG5vZGUuY29udGV4dC5pbXBvcnRzLmZpbHRlcihpID0+IGkucGFja2FnZXMpLmZsYXRNYXAoaSA9PiBpLnBhY2thZ2VzLm1hcChwID0+IHAubmFtZS5zdHIpKTsKICBjb25zdCB1c2VSZXF1ZXN0c1BhY2thZ2UgPSBhbGxQYWNrYWdlcy5maWx0ZXIoaSA9PiBpID09PSAicmVxdWVzdHMiKS5sZW5ndGggPiAwOwogIGlmKCFoYXNUaW1lb3V0ICYmIHVzZVJlcXVlc3RzUGFja2FnZSAmJiBub2RlLmZ1bmN0aW9uTmFtZS52YWx1ZSA9PT0gImdldCIgJiYgbm9kZS5tb2R1bGVPck9iamVjdC52YWx1ZSA9PT0gInJlcXVlc3RzIil7CiAgICBjb25zdCBlcnJvciA9IGJ1aWxkRXJyb3Iobm9kZS5zdGFydC5saW5lLCBub2RlLnN0YXJ0LmNvbCwgbm9kZS5lbmQubGluZSwgbm9kZS5lbmQuY29sLCAidGltZW91dCBub3QgZGVmaW5lZCIsICJDUklUSUNBTCIsICJTQUZFVFkiKTsKICAgIGNvbnN0IGxpbmVUb0luc2VydCA9IGFyZ3VtZW50c1thcmd1bWVudHMubGVuZ3RoIC0gMV0uZW5kLmxpbmU7CiAgICBjb25zdCBjb2xUb0luc2VydCA9IGFyZ3VtZW50c1thcmd1bWVudHMubGVuZ3RoIC0gMV0uZW5kLmNvbDsKICAgIGNvbnN0IGVkaXQgPSBidWlsZEVkaXRBZGQobGluZVRvSW5zZXJ0LCBjb2xUb0luc2VydCwgIiwgdGltZW91dD01IikKICAgIGNvbnN0IGZpeCA9IGJ1aWxkRml4KCJhZGQgdGltZW91dCBhcmd1bWVudCIsIFtlZGl0XSk7CiAgICBhZGRFcnJvcihlcnJvci5hZGRGaXgoZml4KSk7CiAgfQp9")
+                          .regex(null)
+                          .treeSitterQuery(null)
+                          .variables(null)
+                          .build()))
+              .createAnalyzerWarmupCodeData(),
+          new AnalyzerWarmupCodeDataBuilder()
+              .setFilename("pythoncode.py")
+              .setCode(
+                  "aW1wb3J0IHN1YnByb2Nlc3MKc3VicHJvY2Vzcy5Qb3BlbignL2Jpbi9scyAlcycgJSAoJ3NvbWV0aGluZycsKSwgc2hlbGw9VHJ1ZSk=")
+              .setLanguage(Language.PYTHON)
+              .setAnalyzerRuleList(
+                  List.of(
+                      AnalyzerRule.builder()
+                          .name("subprocess-shell-true")
+                          .description("subprocess-shell-true description")
+                          .language(Language.PYTHON)
+                          .type(RuleType.AST_CHECK)
+                          .entityChecked(EntityChecked.FUNCTION_CALL)
+                          .code("ZnVuY3Rpb24gdmlzaXQobm9kZSwgZmlsZW5hbWUsIGNvZGUpIHsKICBpZiAoIW5vZGUuYXJndW1lbnRzIHx8ICFub2RlLmNvbnRleHQgfHwgIW5vZGUuYXJndW1lbnRzLnZhbHVlcyB8fCAhbm9kZS5mdW5jdGlvbk5hbWUpewogICAgcmV0dXJuOwogIH0KICAKICBjb25zdCBmdW5jdGlvbnMgPSBbIlBvcGVuIiwgInJ1biIsICJjYWxsIl07CiAgCiAgaWYgKCFmdW5jdGlvbnMuaW5jbHVkZXMobm9kZS5mdW5jdGlvbk5hbWUudmFsdWUpKSB7CiAgICByZXR1cm47CiAgfQogIAogIGZ1bmN0aW9ucy5mb3JFYWNoKGZ1bmN0aW9uTmFtZSA9PiB7CiAgICBjb25zdCBoYXNTaGVsbFRydWUgPSBub2RlLmFyZ3VtZW50cy52YWx1ZXMuZmlsdGVyKGEgPT4gYS5uYW1lICYmIGEubmFtZS52YWx1ZSA9PSAic2hlbGwiICYmIGEudmFsdWUgJiYgYS52YWx1ZS52YWx1ZSA9PSAiVHJ1ZSIpLmxlbmd0aCA+IDA7CiAgICBjb25zdCBhbGxQYWNrYWdlcyA9IG5vZGUuY29udGV4dC5pbXBvcnRzLmZpbHRlcihpID0+IGkucGFja2FnZXMpLmZsYXRNYXAoaSA9PiBpLnBhY2thZ2VzLm1hcChwID0+IHAubmFtZS5zdHIpKTsKICAgIGNvbnN0IHVzZVN1YnByb2Nlc3NQYWNrYWdlID0gYWxsUGFja2FnZXMuZmlsdGVyKGkgPT4gaSA9PT0gInN1YnByb2Nlc3MiKS5sZW5ndGggPiAwOwogICAgY29uc3QgaW1wb3J0RnJvbSA9IG5vZGUuY29udGV4dC5pbXBvcnRzCiAgICAgICAgLmZpbHRlcihyID0+IHIucGtnICYmIHIucGtnLnZhbHVlID09PSAic3VicHJvY2VzcyIgJiYgci5lbGVtZW50cyAmJiByLmVsZW1lbnRzLmZpbHRlcihlID0+IGUubmFtZSkubWFwKGUgPT4gZS5uYW1lLnZhbHVlKS5pbmNsdWRlcyhmdW5jdGlvbk5hbWUpKTsKICAgIGNvbnN0IHVzZUltcG9ydEZyb20gPSBpbXBvcnRGcm9tLmxlbmd0aCA+IDA7CiAgICBpZigoaGFzU2hlbGxUcnVlICYmIHVzZVN1YnByb2Nlc3NQYWNrYWdlICYmIG5vZGUuZnVuY3Rpb25OYW1lLnZhbHVlID09PSBmdW5jdGlvbk5hbWUgJiYgbm9kZS5tb2R1bGVPck9iamVjdC52YWx1ZSA9PT0gInN1YnByb2Nlc3MiKXx8CiAgICAgICAodXNlSW1wb3J0RnJvbSAmJiBub2RlLmZ1bmN0aW9uTmFtZS52YWx1ZSA9PT0gZnVuY3Rpb25OYW1lKSl7CiAgICAgIAogICAgICAKICAgICAgZm9yICh2YXIgaSA9IDAgOyBpIDwgbm9kZS5hcmd1bWVudHMudmFsdWVzLmxlbmd0aCA7IGkrKykgewogICAgICAgIGNvbnN0IGFyZyA9IG5vZGUuYXJndW1lbnRzLnZhbHVlc1tpXTsKICAgICAgICBjb25zdCBuYkFyZ3VtZW50cyA9IG5vZGUuYXJndW1lbnRzLnZhbHVlcy5sZW5ndGg7CiAgICAgICAgaWYoYXJnLm5hbWUgJiYgYXJnLm5hbWUudmFsdWUgPT0gInNoZWxsIiAmJiBhcmcudmFsdWUgJiYgYXJnLnZhbHVlLnZhbHVlID09ICJUcnVlIikgewogICAgICAgICAgdmFyIGVycm9yID0gYnVpbGRFcnJvcihub2RlLnN0YXJ0LmxpbmUsIG5vZGUuc3RhcnQuY29sLCBub2RlLmVuZC5saW5lLCBub2RlLmVuZC5jb2wsICJzaGVsbCBkZWZpbmVkIHdpdGggdHJ1ZSIsICJDUklUSUNBTCIsICJTRUNVUklUWSIpOwoKCgkJCQkJaWYoaSA+IDApIHsKICAgICAgICAgICBjb25zdCBwcmV2aW91c0FyZ3VtZW50ID0gbm9kZS5hcmd1bWVudHMudmFsdWVzW2ktMV07CiAgICAgICAgICAgY29uc3QgZWRpdCA9IGJ1aWxkRWRpdFJlbW92ZShwcmV2aW91c0FyZ3VtZW50LmVuZC5saW5lLCBwcmV2aW91c0FyZ3VtZW50LmVuZC5jb2wsCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICBhcmcuZW5kLmxpbmUsIGFyZy5lbmQuY29sKQogICAgCQkJIGNvbnN0IGZpeCA9IGJ1aWxkRml4KCJyZW1vdmUgc2hlbGwgYXJndW1lbnQiLCBbZWRpdF0pOwogICAgICAgICAgIGVycm9yID0gZXJyb3IuYWRkRml4KGZpeCk7CiAgICAgICAgICB9CgogICAgICAgICAgCgkJCQkJIGFkZEVycm9yKGVycm9yKTsKICAgICAgICB9CiAgICAgIH0gICAgICAKICAgIH0KICB9KTsKfQ==")
+                          .regex(null)
+                          .treeSitterQuery(null)
+                          .variables(null)
+                          .build()))
+              .createAnalyzerWarmupCodeData());
 }

--- a/server/src/main/java/io/codiga/server/ServerMainController.java
+++ b/server/src/main/java/io/codiga/server/ServerMainController.java
@@ -158,7 +158,18 @@ public class ServerMainController {
                             decodedDescription = new String(Base64.getDecoder().decode(r.description.getBytes()));
                         }
 
-                        return new AnalyzerRule(r.id, decodedDescription, r.language, r.type, r.entityChecked, decodedRuleCode, decodedRegex, decodedTreeSitterQuery, r.variables);
+                        return AnalyzerRule
+                            .builder()
+                            .name(r.id)
+                            .description(decodedDescription)
+                            .language(r.language)
+                            .entityChecked(r.entityChecked)
+                            .type(r.type)
+                            .code(decodedRuleCode)
+                            .regex(decodedRegex)
+                            .treeSitterQuery(decodedTreeSitterQuery)
+                            .variables(r.variables)
+                            .build();
                     }).toList();
         } catch (IllegalArgumentException iae) {
             logger.error("error decoding a rule field: " + request.rules);

--- a/server/src/test/java/io/codiga/server/e2e/python/tsquery/TsQueryListTest.java
+++ b/server/src/test/java/io/codiga/server/e2e/python/tsquery/TsQueryListTest.java
@@ -48,11 +48,13 @@ public class TsQueryListTest extends E2EBase {
                     if(f) {
                         const functionName = f.children.filter(c => c.fieldName === "name")[0];
                         const name = getCodeForNode(functionName, code);
-                        
-                        const error = buildError(functionName.start.line, functionName.start.col, functionName.end.line, functionName.end.col, 
-                                                 "invalid name", "CRITICAL", "security");
-    
-                        addError(error);
+                        if(name === "foo" || name === "foo2") {
+                            const error = buildError(functionName.start.line, functionName.start.col, 
+                            functionName.end.line, functionName.end.col, 
+                                                     "invalid name", "CRITICAL", "security");
+        
+                            addError(error);
+                        }
                     }       
                 });
                          

--- a/server/src/test/java/io/codiga/server/e2e/python/tsquery/TsQueryListTest.java
+++ b/server/src/test/java/io/codiga/server/e2e/python/tsquery/TsQueryListTest.java
@@ -75,6 +75,7 @@ public class TsQueryListTest extends E2EBase {
 
         assertEquals(1, response.ruleResponses.size());
         assertEquals(2, response.ruleResponses.get(0).violations.size());
+        logger.info("output: " + response.ruleResponses.stream().map(r -> r.output).toList());
     }
 
 }


### PR DESCRIPTION
## What problem are you trying to solve?

We want Rosie to be faster. To do so, we need to avoid unnecessary resources allocations.

In this PR, we are doing the following changes

1. Avoid parsing AST rules with ANTLR
2. Avoid parsing code with each tree-sitter rule: parse the code for a file and share the tree among all rules
