### PR TITLE
Support `DATADOG_` and `DD_` prefixed env vars to provide API and APP keys.

### DIFF
--- a/cli/src/main/java/io/codiga/cli/utils/DatadogUtils.java
+++ b/cli/src/main/java/io/codiga/cli/utils/DatadogUtils.java
@@ -107,8 +107,8 @@ public class DatadogUtils {
      * @return the list of rules to use
      */
     public static List<AnalyzerRule> getRulesFromDatadog(Configuration configuration) {
-        var appKey = getCredential(EnvironmentUtils.DATADOG_APP_KEY, EnvironmentUtils.DD_APP_KEY);
         var apiKey = getCredential(EnvironmentUtils.DATADOG_API_KEY, EnvironmentUtils.DD_API_KEY);
+        var appKey = getCredential(EnvironmentUtils.DATADOG_APP_KEY, EnvironmentUtils.DD_APP_KEY);
 
         var siteOptional = EnvironmentUtils.getEnvironmentValue(DD_SITE);
         final String site = siteOptional.orElse(DEFAULT_SITE);
@@ -141,24 +141,24 @@ public class DatadogUtils {
     }
 
     /**
-     * Get a Datadog credential from Environment Variables using both prefixes `DATADOG_` and `DD_`.
+     * Get credential from Environment Variables using a main key and a fallback key.
      * If none variable is set, the process exists with status=2.
-     * If both variables are set, the variable that has the `DATADOG_` prefix is used.
-     * @param datadogKey The environment variable key with the `DATADOG_` prefix.
-     * @param ddKey The environment variable key with the `DD_` prefix.
+     * If both variables are set, the main credential variable is used.
+     * @param credentialKey The main environment variable key.
+     * @param fallbackCredentialKey The fallback environment variable key.
      * @return The credential
      */
-    private static String getCredential(String datadogKey, String ddKey) {
-        var datadogCredentialKey = EnvironmentUtils.getEnvironmentValue(datadogKey);
-        var ddCredentialKey = EnvironmentUtils.getEnvironmentValue(ddKey);
+    private static String getCredential(String credentialKey, String fallbackCredentialKey) {
+        var credentialVal = EnvironmentUtils.getEnvironmentValue(credentialKey);
+        var fallbackCredentialVal = EnvironmentUtils.getEnvironmentValue(fallbackCredentialKey);
 
-        if (datadogCredentialKey.isEmpty() && ddCredentialKey.isEmpty()) {
-            System.err.println(String.format("Variable %s not defined", datadogKey));
+        if (credentialVal.isEmpty() && fallbackCredentialVal.isEmpty()) {
+            System.err.println(String.format("Variable %s not defined", credentialKey));
             System.exit(2);
             return null;
-        } else if(datadogCredentialKey.isPresent() && ddCredentialKey.isPresent()) {
-            System.out.println(String.format("WARNING: both %s and %s environment variables are defined, using %s", datadogKey, ddKey, datadogKey));
-            return datadogCredentialKey.get();
-        } else return datadogCredentialKey.orElseGet(ddCredentialKey::get);
+        } else if(credentialVal.isPresent() && fallbackCredentialVal.isPresent()) {
+            System.out.println(String.format("WARNING: both %s and %s environment variables are defined, using %s", credentialKey, fallbackCredentialKey, credentialKey));
+            return credentialVal.get();
+        } else return credentialVal.orElseGet(fallbackCredentialVal::get);
     }
 }

--- a/cli/src/main/java/io/codiga/cli/utils/DatadogUtils.java
+++ b/cli/src/main/java/io/codiga/cli/utils/DatadogUtils.java
@@ -1,6 +1,6 @@
 package io.codiga.cli.utils;
 
-import static io.codiga.utils.EnvironmentUtils.DATADOG_SITE;
+import static io.codiga.utils.EnvironmentUtils.DD_SITE;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -107,9 +107,9 @@ public class DatadogUtils {
      * @return the list of rules to use
      */
     public static List<AnalyzerRule> getRulesFromDatadog(Configuration configuration) {
-        var appKey = EnvironmentUtils.getEnvironmentValue(EnvironmentUtils.DATADOG_APP_KEY);
-        var apiKey = EnvironmentUtils.getEnvironmentValue(EnvironmentUtils.DATADOG_API_KEY);
-        var siteOptional = EnvironmentUtils.getEnvironmentValue(DATADOG_SITE);
+        var appKey = EnvironmentUtils.getEnvironmentValue(EnvironmentUtils.DATADOG_APP_KEY, EnvironmentUtils.getEnvironmentValue(EnvironmentUtils.DD_APP_KEY, ""));
+        var apiKey = EnvironmentUtils.getEnvironmentValue(EnvironmentUtils.DATADOG_API_KEY, EnvironmentUtils.getEnvironmentValue(EnvironmentUtils.DD_API_KEY, ""));
+        var siteOptional = EnvironmentUtils.getEnvironmentValue(DD_SITE);
         final String site = siteOptional.orElse(DEFAULT_SITE);
         List<AnalyzerRule> result = new ArrayList<>();
 
@@ -131,8 +131,8 @@ public class DatadogUtils {
             var request = HttpRequest.newBuilder(
                     URI.create(String.format("https://api.%s/api/v2/static-analysis/rulesets/%s", site, ruleset)))
                 .header("accept", "application/json")
-                .header("dd-api-key", apiKey.get())
-                .header("dd-application-key", appKey.get())
+                .header("dd-api-key", apiKey)
+                .header("dd-application-key", appKey)
                 .build();
 
             try {

--- a/cli/src/main/java/io/codiga/cli/utils/DatadogUtils.java
+++ b/cli/src/main/java/io/codiga/cli/utils/DatadogUtils.java
@@ -107,22 +107,12 @@ public class DatadogUtils {
      * @return the list of rules to use
      */
     public static List<AnalyzerRule> getRulesFromDatadog(Configuration configuration) {
-        var appKey = EnvironmentUtils.getEnvironmentValue(EnvironmentUtils.DATADOG_APP_KEY, EnvironmentUtils.getEnvironmentValue(EnvironmentUtils.DD_APP_KEY, ""));
-        var apiKey = EnvironmentUtils.getEnvironmentValue(EnvironmentUtils.DATADOG_API_KEY, EnvironmentUtils.getEnvironmentValue(EnvironmentUtils.DD_API_KEY, ""));
+        var appKey = getCredential(EnvironmentUtils.DATADOG_APP_KEY, EnvironmentUtils.DD_APP_KEY);
+        var apiKey = getCredential(EnvironmentUtils.DATADOG_API_KEY, EnvironmentUtils.DD_API_KEY);
+
         var siteOptional = EnvironmentUtils.getEnvironmentValue(DD_SITE);
         final String site = siteOptional.orElse(DEFAULT_SITE);
         List<AnalyzerRule> result = new ArrayList<>();
-
-
-        if (apiKey.isEmpty()) {
-            System.err.println(String.format("Variable %s not defined", EnvironmentUtils.DATADOG_API_KEY));
-            System.exit(2);
-        }
- 
-        if (appKey.isEmpty()) {
-            System.err.println(String.format("Variable %s not defined", EnvironmentUtils.DATADOG_APP_KEY));
-            System.exit(2);
-        }
 
         for (String ruleset : configuration.getRulesets()) {
             var client = HttpClient.newHttpClient();
@@ -148,5 +138,27 @@ public class DatadogUtils {
             }
         }
         return result;
+    }
+
+    /**
+     * Get a Datadog credential from Environment Variables using both prefixes `DATADOG_` and `DD_`.
+     * If none variable is set, the process exists with status=2.
+     * If both variables are set, the variable that has the `DATADOG_` prefix is used.
+     * @param datadogKey The environment variable key with the `DATADOG_` prefix.
+     * @param ddKey The environment variable key with the `DD_` prefix.
+     * @return The credential
+     */
+    private static String getCredential(String datadogKey, String ddKey) {
+        var datadogCredentialKey = EnvironmentUtils.getEnvironmentValue(datadogKey);
+        var ddCredentialKey = EnvironmentUtils.getEnvironmentValue(ddKey);
+
+        if (datadogCredentialKey.isEmpty() && ddCredentialKey.isEmpty()) {
+            System.err.println(String.format("Variable %s not defined", datadogKey));
+            System.exit(2);
+            return null;
+        } else if(datadogCredentialKey.isPresent() && ddCredentialKey.isPresent()) {
+            System.out.println(String.format("WARNING: both %s and %s environment variables are defined, using %s", datadogKey, ddKey, datadogKey));
+            return datadogCredentialKey.get();
+        } else return datadogCredentialKey.orElseGet(ddCredentialKey::get);
     }
 }

--- a/core/src/main/java/io/codiga/utils/EnvironmentUtils.java
+++ b/core/src/main/java/io/codiga/utils/EnvironmentUtils.java
@@ -10,9 +10,11 @@ public class EnvironmentUtils {
 
     public final static String DATADOG_HOSTNAME = "localhost";
     public final static String DATADOG_PORT = "8125";
-    public static final String DATADOG_API_KEY = "DD_API_KEY";
-    public static final String DATADOG_APP_KEY = "DD_APP_KEY";
-    public static final String DATADOG_SITE = "DD_SITE";
+    public static final String DATADOG_API_KEY = "DATADOG_API_KEY";
+    public static final String DATADOG_APP_KEY = "DATADOG_APP_KEY";
+    public static final String DD_API_KEY = "DD_API_KEY";
+    public static final String DD_APP_KEY = "DD_APP_KEY";
+    public static final String DD_SITE = "DD_SITE";
 
     public final static String PYTHON_FORCE_ANTLR = "PYTHON_FORCE_ANTLR";
 
@@ -28,6 +30,20 @@ public class EnvironmentUtils {
      */
     public static Optional<String> getEnvironmentValue(String variable) {
         return Optional.ofNullable(System.getenv(variable));
+    }
+
+    /**
+     * Get an environment variable. If it does not exits, returns the default value
+     *
+     * @param variable
+     * @return
+     */
+    public static String getEnvironmentValue(String variable, String defaultVal) {
+        var envVar = System.getenv(variable);
+        if (envVar == null) {
+            return defaultVal;
+        }
+        return envVar;
     }
 
     public static Optional<Integer> getEnvironmentValueAsNumber(String variable) {

--- a/core/src/main/java/io/codiga/utils/EnvironmentUtils.java
+++ b/core/src/main/java/io/codiga/utils/EnvironmentUtils.java
@@ -32,20 +32,6 @@ public class EnvironmentUtils {
         return Optional.ofNullable(System.getenv(variable));
     }
 
-    /**
-     * Get an environment variable. If it does not exits, returns the default value
-     *
-     * @param variable
-     * @return
-     */
-    public static String getEnvironmentValue(String variable, String defaultVal) {
-        var envVar = System.getenv(variable);
-        if (envVar == null) {
-            return defaultVal;
-        }
-        return envVar;
-    }
-
     public static Optional<Integer> getEnvironmentValueAsNumber(String variable) {
         try {
             return getEnvironmentValue(variable).map(Integer::parseInt);


### PR DESCRIPTION
## What problem are you trying to solve?

We want to support both `DATADOG_` and `DD_` prefixed environment variable keys to provide both API Key and APP Keys

## What is your solution?

In this PR we're adding the support for using:

* `DATADOG_API_KEY`
* `DATADOG_APP_KEY`
* `DD_API_KEY`
* `DD_APP_KEY`

as Environment Variables to provide the required keys for the analyzer to work properly.
