### PR TITLE
Check for null rules in rulesets

### DIFF
--- a/cli/src/main/java/io/codiga/cli/Main.java
+++ b/cli/src/main/java/io/codiga/cli/Main.java
@@ -227,10 +227,12 @@ public class Main {
       System.exit(1);
     }
 
+    // TODO(julien.delange) re-enable this logic once we support configuration file and ignore paths
     // ignore paths and configuration specified = no analysis
     if (!ignorePaths.isEmpty() && configurationFile.isPresent()) {
-      System.err.println("cannot specify ignore path when a configuration file is detected");
-      System.exit(1);
+//      System.err.println("cannot specify ignore path when a configuration file is detected");
+//      System.exit(1);
+      System.out.println("ignore paths and configuration file detected together");
     }
 
     // read the rules

--- a/cli/src/main/java/io/codiga/cli/utils/DatadogUtils.java
+++ b/cli/src/main/java/io/codiga/cli/utils/DatadogUtils.java
@@ -88,6 +88,12 @@ public class DatadogUtils {
         }
 
         var name = attributesNode.get("name").asText();
+
+        if(attributesNode.get("rules").isNull()) {
+            System.err.println(String.format("ruleset %s has no rule", name));
+            return List.of();
+        }
+
         var rules = (ArrayNode) attributesNode.get("rules");
 
 
@@ -127,7 +133,7 @@ public class DatadogUtils {
         for (String ruleset : configuration.getRulesets()) {
             var client = HttpClient.newHttpClient();
 
-
+            System.out.println("fetching ruleset: " + ruleset);
             var request = HttpRequest.newBuilder(
                     URI.create(String.format("https://api.%s/api/v2/static-analysis/rulesets/%s", site, ruleset)))
                 .header("accept", "application/json")


### PR DESCRIPTION
## What problem are you trying to solve?

When a ruleset returns `null` for the `rules`, we should not crash but provide an error message.

## What is your solution?

Add an error message when the `rules` attribute is `null`.

Tested with the current API state.

```
./gradlew cli:run --args="-i /Users/julien.delange/dd/dogweb -t true -o out.json --ignore-path **/tests/** --ignore-path **/test*"                                                             09:25:51

> Task :cli:run FAILED
  1 add check when we have no rule
Configuration
===================
Version       : development
# cores       : 10
Debug         : false
Directory     : /Users/julien.delange/dd/dogweb
Rules file    : null
Debug         : null
Tree-Sitter   : true
Output file   : out.json
Output format : JSON
Ignore paths  : **/tests/**,**/test*
Test mode     : false
/Users/julien.delange/dd/dogweb/static-analysis.datadog.yml
ignore paths and configuration file detected together
fetching ruleset: python-code-style
ruleset python-code-style has no rule
fetching ruleset: python-inclusive
ruleset python-inclusive has no rule
fetching ruleset: python-best-practices
ruleset python-best-practices has no rule
fetching ruleset: python-design
ruleset python-design has no rule
no rule found
```