### PR TITLE
Handle ignore-paths from the configuration file

### DIFF
--- a/cli/src/main/java/io/codiga/cli/utils/DatadogUtils.java
+++ b/cli/src/main/java/io/codiga/cli/utils/DatadogUtils.java
@@ -31,8 +31,6 @@ public class DatadogUtils {
      * @return
      */
     public static Optional<AnalyzerRule> getRuleFromJson(JsonNode node, String rulesetName) {
-        System.out.println(node.toString());
-
         ObjectMapper mapper = new ObjectMapper();
         mapper.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
 
@@ -123,7 +121,6 @@ public class DatadogUtils {
         for (String ruleset : configuration.getRulesets()) {
             var client = HttpClient.newHttpClient();
 
-            System.out.println("fetching ruleset: " + ruleset);
             var request = HttpRequest.newBuilder(
                     URI.create(String.format("https://api.%s/api/v2/static-analysis/rulesets/%s", site, ruleset)))
                 .header("accept", "application/json")


### PR DESCRIPTION
## What problem are you trying to solve?

We want to be able to ignore paths/files based on the `static-analysis.datadog.yml` file. Today, the CLI returns an error when we specify the `--ignore-paths` switch.


## What is your solution?

When the configuration file is present, take the ignored paths list from the YAML file. Otherwise, take the results from the command line.

```yaml
rulesets:
  - python-best-practices
  - python-code-style
  - python-inclusive
  - python-design

ignore-paths:
  -  "**/tests/**"
  -  "**/test*"
```

Tested with

`./gradlew cli:run --args="-i /Users/julien.delange/dd/dogweb -t true -o out.json --ignore-path **/tests/** --ignore-path **/test*"`

and 
`./gradlew cli:run --args="-i /Users/julien.delange/dd/dogweb -t true -o out.json"`
