### PR TITLE
Fix getCode helper

### DIFF
--- a/core/src/main/java/io/codiga/analyzer/ast/vm/VmContext.java
+++ b/core/src/main/java/io/codiga/analyzer/ast/vm/VmContext.java
@@ -61,7 +61,7 @@ public class VmContext {
               startChar = startChar + startCol;
 
               var endChar = 0;
-              for (var i = 0 ; i < startLine ; i++) {
+              for (var i = 0 ; i < endLine ; i++) {
                 endChar = endChar + lines[i].length + 1;
               }
               endChar = endChar + endCol;


### PR DESCRIPTION
## What problem are you trying to solve?

The `getCode` or `getCodeForNode` helper functions don't return the correct code for multi line nodes.

## What is your solution?

Fix the `endLine` typo?

## Alternatives considered

None.

## What the reviewer should know

Nope.