### PR TITLE
Support configuration file with both `.yml` and `.yaml` extension

### DIFF
--- a/cli/src/main/java/io/codiga/cli/Main.java
+++ b/cli/src/main/java/io/codiga/cli/Main.java
@@ -216,6 +216,10 @@ public class Main {
     // read the datadog configuration
     Optional<Configuration> configurationFile = Optional.empty();
     Path configurationPath = Paths.get(directory, DATADOG_CONFIGURATION_FILE);
+    if (Files.notExists(configurationPath)) {
+      configurationPath = Paths.get(directory, DATADOG_CONFIGURATION_FILE.replaceFirst("\\.yml", ".yaml"));
+    }
+
     System.out.println(configurationPath);
     if (Files.isReadable(configurationPath) && Files.isRegularFile(configurationPath)) {
       configurationFile = getConfigurationFromFile(new File(configurationPath.toUri()));


### PR DESCRIPTION
## What problem are you trying to solve?

YAML files can use both `.yml` and `.yaml` extension. The onboarding UX is being affected by this fact as some users are creating the configuration file using `.yaml` extension, and the analyzer currently only supports `.yml` files.

## What is your solution?

If the analyzer cannot open the Static Analysis configuration file using the `.yml` extension, the analyzer will try to do it using using `.yaml` extension.

## Alternatives considered

N/A

## What the reviewer should know

Tested in a repository using both `.yml` and `.yaml` configuration files
